### PR TITLE
Bug 1212189 - restore the "sort=oldest" option to the API.

### DIFF
--- a/syncstorage/storage/__init__.py
+++ b/syncstorage/storage/__init__.py
@@ -222,7 +222,7 @@ class SyncStorage(object):
             newer: float; only return items newer than this timestamp.
             limit: integer; return at most this many items.
             offset: string; an offset vale previously returned as next_offset.
-            sort: sort order for results; one of "newer" or "index".
+            sort: sort order for results; one of "newest", "oldest" or "index".
 
         Returns:
             A dict with the following keys:
@@ -246,7 +246,7 @@ class SyncStorage(object):
             newer: float; only return items newer than this timestamp.
             limit: integer; return at most this many items.
             offset: string; an offset vale previously returned as next_offset.
-            sort: sort order for results; one of "oldest", "newer" or "index".
+            sort: sort order for results; one of "newest", "oldest" or "index".
 
         Returns:
             A dict with the following keys:

--- a/syncstorage/storage/memcached.py
+++ b/syncstorage/storage/memcached.py
@@ -778,10 +778,12 @@ class _CachedManagerBase(object):
         # Using the id as a secondary key produces a unique ordering.
         bsos = list(bsos)
         if sort == "index":
+            reverse = True
             key = lambda bso: (bso["sortindex"], bso["id"])
         else:
+            reverse = False if sort == "oldest" else True
             key = lambda bso: (bso["modified"], bso["id"])
-        bsos.sort(key=key, reverse=True)
+        bsos.sort(key=key, reverse=reverse)
         # Trim to the specified offset, if any.
         # Note that we defaulted it to zero above.
         if offset is not None:

--- a/syncstorage/storage/sql/queries_generic.py
+++ b/syncstorage/storage/sql/queries_generic.py
@@ -113,8 +113,10 @@ def FIND_ITEMS(bso, params):
         query = query.where(bso.c.id.in_(params.get("ids")))
     if "newer" in params:
         query = query.where(bso.c.modified > bindparam("newer"))
-    if "older" in params:
-        query = query.where(bso.c.modified <= bindparam("older"))
+    if "newer_eq" in params:
+        query = query.where(bso.c.modified >= bindparam("newer_eq"))
+    if "older_eq" in params:
+        query = query.where(bso.c.modified <= bindparam("older_eq"))
     if "ttl" in params:
         query = query.where(bso.c.ttl > bindparam("ttl"))
     # Sort it in the order requested.
@@ -126,6 +128,8 @@ def FIND_ITEMS(bso, params):
     sort = params.get("sort", None)
     if sort == 'index':
         query = query.order_by(bso.c.sortindex.desc())
+    elif sort == 'oldest':
+        query = query.order_by(bso.c.modified.asc())
     else:
         query = query.order_by(bso.c.modified.desc())
     # Apply limit and/or offset.

--- a/syncstorage/views/validators.py
+++ b/syncstorage/views/validators.py
@@ -122,7 +122,7 @@ def extract_query_params(request):
 
     sort = request.GET.get("sort")
     if sort is not None:
-        if sort not in ("newest", "index"):
+        if sort not in ("newest", "oldest", "index"):
             msg = "Invalid value for sort: %r" % (sort,)
             request.errors.add("querystring", "sort", msg)
         else:


### PR DESCRIPTION
This was removed in the sync1.1 -> sync1.5 transition because clients
weren't using it, but we have new clients and they want to use it.

https://bugzilla.mozilla.org/show_bug.cgi?id=1212189