### PR TITLE
Tweaks to get tests passing on batch uploads PR

### DIFF
--- a/syncstorage/storage/sql/queries_generic.py
+++ b/syncstorage/storage/sql/queries_generic.py
@@ -99,36 +99,25 @@ CREATE_BATCH = "INSERT INTO batch_uploads (batch, userid, collection) "\
 VALID_BATCH = "SELECT batch FROM batch_uploads WHERE batch = :batch " \
                     "AND userid = :userid AND collection = :collection"
 
-APPEND_ITEMS_TO_BATCH = "INSERT INTO %(bui)s "\
-                              "  (batch, id, sortindex, modified, payload, "\
-                              "   payload_size, ttl) "\
-                              "VALUES "\
-                              "  (:batchid, :id, :sortindex, :modified, "\
-                              "   :payload, :payload_size, :ttl) "\
-                              "ON DUPLICATE KEY UPDATE "\
-                              "  sortindex = VALUES(sortindex), "\
-                              "  payload = VALUES(payload), "\
-                              "  payload_size = VALUES(payload_size) "\
-                              "  ttl = VALUES(ttl)"
-
-APPLY_BATCH = "INSERT INTO %(bso)s "\
-                     "  (userid, collection, id, sortindex, modified, "\
-                     "   payload, payload_size, ttl) "\
-                     "SELECT "\
-                     "  :userid, :collection, id, sortindex, :modified, " \
-                     "  COALESCE(payload, \"\"), COALESCE(payload_size, 0), "\
-                     "  COALESCE(ttl, ttl + :default_ttl) "\
-                     "FROM %(bui)s "\
-                     "WHERE batch = :batch "\
-                     "ON DUPLICATE KEY UPDATE "\
-                     "  sortindex = COALESCE(VALUES(sortindex), " \
-                     "                       %(bso)s.sortindex), " \
-                     "  modified = :modified, " \
-                     "  payload = COALESCE(VALUES(payload), " \
-                     "                     %(bso)s.payload), "\
-                     "  payload_size = COALESCE(VALUES(payload_size),"\
-                     "                          %(bso)s.payload_size), "\
-                     "  ttl = COALESCE(VALUES(ttl), %(bso)s.ttl)"
+APPLY_BATCH = "INSERT OR REPLACE INTO %(bso)s" \
+              "    (userid, collection, id, sortindex, payload," \
+              "     payload_size, ttl, modified)" \
+              "  SELECT booey.userid, booey.collection, booey.id," \
+              "     COALESCE(booey.sortindex, %(bso)s.sortindex)," \
+              "     COALESCE(booey.payload, %(bso)s.payload, '')," \
+              "     COALESCE(booey.payload_size, %(bso)s.payload_size, 0)," \
+              "     COALESCE(booey.ttl, %(bso)s.ttl, 2100000000)," \
+              "     :modified" \
+              "  FROM (SELECT batch_uploads.batch, batch_uploads.userid," \
+              "               batch_uploads.collection, %(bui)s.id," \
+              "               sortindex, payload, payload_size, ttl" \
+              "        FROM %(bui)s" \
+              "        LEFT JOIN batch_uploads" \
+              "        ON %(bui)s.batch = batch_uploads.batch" \
+              "        WHERE %(bui)s.batch = :batch) AS booey" \
+              "  LEFT JOIN %(bso)s ON booey.userid = %(bso)s.userid AND" \
+              "                   booey.collection = %(bso)s.collection AND" \
+              "                   booey.id = %(bso)s.id"
 
 CLOSE_BATCH = "DELETE FROM batch_uploads WHERE batch = :batch " \
               "AND userid = :userid AND collection = :collection"

--- a/syncstorage/storage/sql/queries_mysql.py
+++ b/syncstorage/storage/sql/queries_mysql.py
@@ -17,3 +17,22 @@ PURGE_SOME_EXPIRED_ITEMS = "DELETE FROM %(bso)s "\
 PURGE_BATCH_CONTENTS = "DELETE FROM %(bui)s " \
                        "WHERE batch < (UNIX_TIMESTAMP() - :grace) * 1000 " \
                        "ORDER BY ttl LIMIT :maxitems"
+
+APPLY_BATCH = "INSERT INTO %(bso)s "\
+                     "  (userid, collection, id, sortindex, modified, "\
+                     "   payload, payload_size, ttl) "\
+                     "SELECT "\
+                     "  :userid, :collection, id, sortindex, :modified, " \
+                     "  COALESCE(payload, \"\"), COALESCE(payload_size, 0), "\
+                     "  COALESCE(ttl, ttl + :default_ttl) "\
+                     "FROM %(bui)s "\
+                     "WHERE batch = :batch "\
+                     "ON DUPLICATE KEY UPDATE "\
+                     "  sortindex = COALESCE(VALUES(sortindex), " \
+                     "                       %(bso)s.sortindex), " \
+                     "  modified = :modified, " \
+                     "  payload = COALESCE(VALUES(payload), " \
+                     "                     %(bso)s.payload), "\
+                     "  payload_size = COALESCE(VALUES(payload_size),"\
+                     "                          %(bso)s.payload_size), "\
+                     "  ttl = COALESCE(VALUES(ttl), %(bso)s.ttl)"

--- a/syncstorage/storage/sql/queries_postgres.py
+++ b/syncstorage/storage/sql/queries_postgres.py
@@ -58,3 +58,11 @@ $do$;
 PURGE_SOME_EXPIRED_ITEMS = \
     "DELETE FROM %(bso)s "\
     "WHERE ttl < (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) - :grace)"
+
+PURGE_BATCHES = "DELETE FROM batch_uploads WHERE batch < " \
+                "(SELECT EXTRACT(EPOCH FROM CURRENT_TIMSTAMP) - :grace) " \
+                "  * 1000"
+
+PURGE_BATCH_CONTENTS = "DELETE FROM %(bui)s WHERE batch < " \
+                       "  (SELECT EXTRACT(EPOCH FROM CURRENT_TIMSTAMP) " \
+                       "     - :grace) * 1000"

--- a/syncstorage/storage/sql/queries_sqlite.py
+++ b/syncstorage/storage/sql/queries_sqlite.py
@@ -23,30 +23,6 @@ LOCK_COLLECTION_WRITE = "SELECT last_modified FROM user_collections "\
 PURGE_SOME_EXPIRED_ITEMS = "DELETE FROM %(bso)s "\
                            "WHERE ttl < (strftime('%%s', 'now') - :grace) "
 
-APPLY_BATCH = "INSERT OR REPLACE INTO %(bso)s" \
-              "    (userid, collection, id, sortindex, payload," \
-              "     payload_size, ttl, modified)" \
-              "  SELECT booey.userid, booey.collection, booey.id," \
-              "         :modified," \
-              "         COALESCE(booey.sortindex, %(bso)s.sortindex)," \
-              "         COALESCE(booey.payload, %(bso)s.payload, "")," \
-              "         COALESCE(booey.payload_size, %(bso)s.payload_size," \
-              "                  0)," \
-              "         COALESCE(booey.ttl, %(bso)s.ttl, 2100000000)" \
-              "  FROM (SELECT batch_uploads.batch, batch_uploads.userid," \
-              "               batch_uploads.collection, %(bui)s.id," \
-              "               sortindex, payload, payload_size, ttl" \
-              "        FROM %(bui)s" \
-              "        LEFT JOIN batch_uploads" \
-              "        ON %(bui)s.batch = batch_uploads.batch" \
-              "        WHERE %(bui)s.batch = :batch) AS booey" \
-              "  LEFT JOIN %(bso)s ON booey.userid = %(bso)s.userid AND" \
-              "                   booey.collection = %(bso)s.collection AND" \
-              "                   booey.id = %(bso)s.id"
-
-PURGE_SOME_EXPIRED_ITEMS = "DELETE FROM %(bso)s WHERE ttl < " \
-                           "(SELECT strftime('%%s', 'now') - :grace)"
-
 PURGE_BATCHES = "DELETE FROM batch_uploads WHERE batch < " \
                 "   (SELECT strftime('%%s', 'now') - :grace) * 1000"
 

--- a/syncstorage/tests/functional/test_old_storage.py
+++ b/syncstorage/tests/functional/test_old_storage.py
@@ -20,10 +20,7 @@ from decimal import Decimal
 
 from syncstorage.tests.functional.support import StorageFunctionalTestCase
 from syncstorage.tests.functional.support import run_live_functional_tests
-from syncstorage.views.validators import (
-    DEFAULT_BATCH_MAX_COUNT,
-    DEFAULT_BATCH_MAX_BYTES,
-)
+from syncstorage.views.util import get_limit_config
 
 WEAVE_INVALID_WBO = 8
 
@@ -416,11 +413,8 @@ class TestOldStorage(StorageFunctionalTestCase):
         self.assertEquals(len(res.json), 0)
 
     def test_batch(self):
-        settings = self.config.registry.settings
-        max_count = settings.get("storage.batch_max_count",
-                                 DEFAULT_BATCH_MAX_COUNT)
-        max_bytes = settings.get("storage.batch_max_bytes",
-                                 DEFAULT_BATCH_MAX_BYTES)
+        max_count = get_limit_config(self.config, "max_post_records")
+        max_bytes = get_limit_config(self.config, "max_post_bytes")
         self.assertEquals(max_bytes, 1024 * 1024)
         # Test that batch uploads are correctly processed.
         # Uploading max_count-5 small objects should succeed.

--- a/syncstorage/tests/test_scripts.py
+++ b/syncstorage/tests/test_scripts.py
@@ -149,7 +149,7 @@ class TestPurgeTTLScript(StorageTestCase):
                                         "ttl": 0},
                                        {"id": "test3", "payload": "Y",
                                         "ttl": 30}])
-        batchid = int((time.time() + 1 - (3 * 60 * 60)) * 1000)
+        batchid = int((time.time() + 2 - (3 * 60 * 60)) * 1000)
         with storage.dbconnector.connect() as c:
             c.execute("INSERT INTO batch_uploads (batch, userid, "
                       "collection) VALUES (:batch, :userid, :collection) "
@@ -182,7 +182,7 @@ class TestPurgeTTLScript(StorageTestCase):
         self.assertEquals(count_bui_items(), 4)
 
         # Necessary for batch_upload_items purging to test reliably
-        time.sleep(1)
+        time.sleep(2)
 
         # Short grace period == not purged
         ini_file = os.path.join(os.path.dirname(__file__), self.TEST_INI_FILE)

--- a/syncstorage/tests/tests.ini
+++ b/syncstorage/tests/tests.ini
@@ -15,7 +15,7 @@ pool_size = 100
 pool_recycle = 3600
 reset_on_return = true
 create_tables = true
-batch_max_count = 4000
+max_post_records = 4000
 
 [hawkauth]
 secret = "TED KOPPEL IS A ROBOT"

--- a/syncstorage/tweens.py
+++ b/syncstorage/tweens.py
@@ -68,6 +68,8 @@ def convert_cornice_errors_to_respcodes(handler, registry):
         try:
             if body["status"] == "quota-exceeded":
                 return WEAVE_OVER_QUOTA
+            if body["status"] == "size-limit-exceeded":
+                return WEAVE_SIZE_LIMIT_EXCEEDED
             error = body["errors"][0]
             if error["location"] == "body":
                 if error["name"] in ("bso", "bsos"):

--- a/syncstorage/views/__init__.py
+++ b/syncstorage/views/__init__.py
@@ -25,7 +25,7 @@ from syncstorage.views.decorators import (convert_storage_errors,
                                           with_collection_lock,
                                           check_precondition_headers,
                                           check_storage_quota)
-from syncstorage.views.util import get_resource_timestamp
+from syncstorage.views.util import get_resource_timestamp, get_limit_config
 
 
 logger = logging.getLogger("syncstorage")
@@ -188,13 +188,16 @@ def get_info_usage(request):
 @info_configuration.get(accept="application/json", renderer="sync-json")
 @default_decorators
 def get_info_configuration(request):
-    settings = request.registry.settings
+    LIMIT_NAMES = (
+        "max_request_bytes",
+        "max_post_records",
+        "max_post_bytes",
+        "max_total_records",
+        "max_total_bytes",
+    )
     limits = {}
-    limits["max_request_bytes"] = settings.get("storage.max_request_bytes", 0)
-    limits["max_post_records"] = settings.get("storage.max_post_records", 0)
-    limits["max_post_bytes"] = settings.get("max_post_bytes", 0)
-    limits["max_batch_records"] = settings.get("max_batch_records", 0)
-    limits["max_batch_bytes"] = settings.get("max_batch_bytes", 0)
+    for name in LIMIT_NAMES:
+        limits[name] = get_limit_config(request, name)
     return limits
 
 

--- a/syncstorage/views/util.py
+++ b/syncstorage/views/util.py
@@ -86,3 +86,19 @@ def get_resource_timestamp(request):
         return storage.get_item_timestamp(userid, collection, item)
     except NotFoundError:
         return 0
+
+
+DEFAULT_LIMITS = {}
+DEFAULT_LIMITS["max_request_bytes"] = 1024 * 1024
+DEFAULT_LIMITS["max_post_records"] = 100
+DEFAULT_LIMITS["max_post_bytes"] = DEFAULT_LIMITS["max_request_bytes"]
+DEFAULT_LIMITS["max_total_records"] = 100 * DEFAULT_LIMITS["max_post_records"]
+DEFAULT_LIMITS["max_total_bytes"] = 100 * DEFAULT_LIMITS["max_post_bytes"]
+
+
+def get_limit_config(request, limit):
+    """Get the configured value for the named size limit."""
+    try:
+        return request.registry.settings["storage." + limit]
+    except KeyError:
+        return DEFAULT_LIMITS[limit]


### PR DESCRIPTION
@rtilder some tweaks to your db queries:

* Move queries with mysql-specific `ON DUPLICATE KEY` logic into `queries_mysql.py`
* Fix syntax error in sqlite `APPLY_BATCH` query due to mis-embedded double quotes
* Try to make some postgres-specific purge queries
* Remove `APPEND_ITEMS_TO_BATCH` which doesn't seem to be used

It doesn't get all the tests passing, but they're passing more than they were for non-mysql backends. @rtilder r?