### PR TITLE
fix functional tests failing against https endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ CMD ["server"]
 # install / cache dependencies first
 COPY requirements.txt /app/requirements.txt
 
-# install depenencies, cleanup and add libstdc++ back in since
+# install dependencies, cleanup and add libstdc++ back in since
 # we the app needs to link to it
-RUN apk add --update build-base && \
+RUN apk add --update build-base ca-certificates && \
     pip install -r requirements.txt && \
     apk del --purge build-base gcc && \
     apk add libstdc++

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,7 +5,7 @@ case "$1" in
     server)
         _SETTINGS_FILE=${SYNC_SETTINGS_FILE:-"/app/example.ini"}
 
-        if [ ! -e $_SETTINGS_FILE ]; then 
+        if [ ! -e $_SETTINGS_FILE ]; then
             echo "Could not find ini file: $_SETTINGS_FILE"
             exit 1
         fi
@@ -42,12 +42,12 @@ case "$1" in
     test_functional)
         echo "test - functional"
         # run functional tests
-	    export MOZSVC_SQLURI=sqlite:///:memory: 
+	    export MOZSVC_SQLURI=sqlite:///:memory:
         gunicorn --paste ./syncstorage/tests/tests.ini \
             --workers 1 \
-            --worker-class mozsvc.gunicorn_worker.MozSvcGeventWorker & 
+            --worker-class mozsvc.gunicorn_worker.MozSvcGeventWorker &
 
-        SERVER_PID=$! 
+        SERVER_PID=$!
         sleep 2
 
         $0 test_endpoint http://localhost:5000
@@ -56,7 +56,7 @@ case "$1" in
         ;;
 
     test_endpoint)
-        python syncstorage/tests/functional/test_storage.py $2
+        exec python syncstorage/tests/functional/test_storage.py $2
         ;;
 
     *)


### PR DESCRIPTION
Added `ca-certificates` to the docker build requirements. Now `test_functional` will work against https endpoints. It failed before because openssl and the ca-certificates were not installed. 

@rfk r?