### PR TITLE
Batch upload ttl fixes

### DIFF
--- a/syncstorage/storage/memcached.py
+++ b/syncstorage/storage/memcached.py
@@ -1038,11 +1038,14 @@ class CachedManager(_CachedManagerBase):
             try:
                 storage = self.storage
                 collection = self.collection
+                ttl_base = int(get_timestamp())
                 with self.owner.lock_for_read(userid, collection):
                     ts = storage.get_collection_timestamp(userid, collection)
                     data["modified"] = ts
                     data["items"] = {}
                     for bso in storage.get_items(userid, collection)["items"]:
+                        if bso.get("ttl") is not None:
+                            bso["ttl"] = ttl_base + bso["ttl"]
                         data["items"][bso["id"]] = bso
                 if add_if_missing:
                     self.cache.add(key, data)

--- a/syncstorage/storage/sql/dbconnect.py
+++ b/syncstorage/storage/sql/dbconnect.py
@@ -179,7 +179,7 @@ def _get_batch_item_columns(table_name):
         Column("sortindex", Integer, nullable=True),
         Column("payload", PAYLOAD_TYPE, nullable=True),
         Column("payload_size", Integer, nullable=True),
-        Column("ttl", Integer, nullable=True)
+        Column("ttl_offset", Integer, nullable=True)
     )
 
 

--- a/syncstorage/storage/sql/dbconnect.py
+++ b/syncstorage/storage/sql/dbconnect.py
@@ -114,28 +114,22 @@ PAYLOAD_TYPE = PAYLOAD_TYPE.with_variant(postgresql.TEXT(), 'postgresql')
 
 # Common column definitions between BSO and batch upload item tables
 
-def _common_columns(ttl):
-    return (
-        Column("sortindex", Integer),
-        Column("modified", BigInteger, nullable=False),
-        # I'd like to default these to the emptry string and zero,
-        # but MySQL doesn't let you set a default on a TEXT column...
-        Column("payload", PAYLOAD_TYPE, nullable=False),
-        Column("payload_size", Integer, nullable=False),
-        Column("ttl", Integer, server_default=sqltext(str(ttl)))
-    )
-
-
 def _get_bso_columns(table_name):
-    identifiers = (
+    return (
         Column("userid", Integer, primary_key=True, nullable=False,
                autoincrement=False),
         Column("collection", Integer, primary_key=True, nullable=False,
                autoincrement=False),
-        Column("id", String(64), primary_key=True, autoincrement=False)
-    )
-    common = _common_columns(MAX_TTL)
-    indexes = (
+        Column("id", String(64), primary_key=True, autoincrement=False),
+        Column("sortindex", Integer),
+        Column("modified", BigInteger, nullable=False),
+        # I'd like to default this to the emptry string, but
+        # MySQL doesn't let you set a default on a TEXT column.
+        Column("payload", PAYLOAD_TYPE, nullable=False),
+        Column("payload_size", Integer, nullable=False,
+               server_default=sqltext("0")),
+        Column("ttl", Integer, nullable=False,
+               server_default=sqltext(str(MAX_TTL))),
         # Declare indexes.
         # We need to include the tablename in the index name due to sharding,
         # because index names in sqlite are global, not per-table.
@@ -148,7 +142,6 @@ def _get_bso_columns(table_name):
         # Clients almost always filter on "modified" using the above index,
         # and cannot take advantage of a separate index for sorting.
     )
-    return identifiers + common + indexes
 
 
 #  If the storage controller is not doing sharding based on userid,
@@ -174,14 +167,20 @@ batch_uploads = Table(
 
 
 def _get_batch_item_columns(table_name):
-    identifiers = (
+    return (
         Column("batch", BigInteger, primary_key=True, nullable=False,
                autoincrement=False),
         Column("id", String(64), primary_key=True, nullable=False,
-               autoincrement=False)
+               autoincrement=False),
+        # All these need to be nullable, because the batch upload
+        # may or may not set each individual field of each item.
+        # Also note that there's no "modified" column because the
+        # modification timestamp gets set on batch commit.
+        Column("sortindex", Integer, nullable=True),
+        Column("payload", PAYLOAD_TYPE, nullable=True),
+        Column("payload_size", Integer, nullable=True),
+        Column("ttl", Integer, nullable=True)
     )
-    common = _common_columns(MAX_TTL)
-    return identifiers + common
 
 
 bui = Table("batch_upload_items", metadata,

--- a/syncstorage/storage/sql/queries_generic.py
+++ b/syncstorage/storage/sql/queries_generic.py
@@ -134,7 +134,7 @@ APPLY_BATCH_UPDATE = """
             0
         ),
         ttl = COALESCE(
-            (SELECT ttl FROM %(bui)s WHERE
+            (SELECT ttl_offset + :ttl_base FROM %(bui)s WHERE
                 batch = :batch AND id = %(bso)s.id),
             %(bso)s.ttl,
             :default_ttl
@@ -163,7 +163,7 @@ APPLY_BATCH_INSERT = """
        %(bui)s.sortindex,
        COALESCE(%(bui)s.payload, ''),
        COALESCE(%(bui)s.payload_size, 0),
-       COALESCE(%(bui)s.ttl, :default_ttl),
+       COALESCE(%(bui)s.ttl_offset + :ttl_base, :default_ttl),
        :modified
     FROM batch_uploads
     LEFT JOIN %(bui)s

--- a/syncstorage/storage/sql/queries_generic.py
+++ b/syncstorage/storage/sql/queries_generic.py
@@ -99,25 +99,86 @@ CREATE_BATCH = "INSERT INTO batch_uploads (batch, userid, collection) "\
 VALID_BATCH = "SELECT batch FROM batch_uploads WHERE batch = :batch " \
                     "AND userid = :userid AND collection = :collection"
 
-APPLY_BATCH = "INSERT OR REPLACE INTO %(bso)s" \
-              "    (userid, collection, id, sortindex, payload," \
-              "     payload_size, ttl, modified)" \
-              "  SELECT booey.userid, booey.collection, booey.id," \
-              "     COALESCE(booey.sortindex, %(bso)s.sortindex)," \
-              "     COALESCE(booey.payload, %(bso)s.payload, '')," \
-              "     COALESCE(booey.payload_size, %(bso)s.payload_size, 0)," \
-              "     COALESCE(booey.ttl, %(bso)s.ttl, 2100000000)," \
-              "     :modified" \
-              "  FROM (SELECT batch_uploads.batch, batch_uploads.userid," \
-              "               batch_uploads.collection, %(bui)s.id," \
-              "               sortindex, payload, payload_size, ttl" \
-              "        FROM %(bui)s" \
-              "        LEFT JOIN batch_uploads" \
-              "        ON %(bui)s.batch = batch_uploads.batch" \
-              "        WHERE %(bui)s.batch = :batch) AS booey" \
-              "  LEFT JOIN %(bso)s ON booey.userid = %(bso)s.userid AND" \
-              "                   booey.collection = %(bso)s.collection AND" \
-              "                   booey.id = %(bso)s.id"
+# The semantics we want for applying a batch are roughly
+# those of an UPSERT, but there's no good generic way
+# to do that.  This is a best-effort, inefficient fallback
+# using only portable SQL syntax, that applies the batch in two
+# parts:
+#
+#  * Update any existing rows in-place, using subselects to
+#    access the data for each such row found.
+#  * Insert any new rows with a single INSERT ... SELECT.
+#
+# Yes, it's horrible, and made even more so due to the need to deal
+# with partial updates.  For production use we expect a db-specific
+# reimplementation that can do this in a single efficient query.
+
+APPLY_BATCH_UPDATE = """
+    UPDATE %(bso)s
+    SET
+        sortindex = COALESCE(
+            (SELECT sortindex FROM %(bui)s WHERE
+                batch = :batch AND id = %(bso)s.id),
+            %(bso)s.sortindex
+        ),
+        payload = COALESCE(
+            (SELECT payload FROM %(bui)s WHERE
+                batch = :batch AND id = %(bso)s.id),
+            %(bso)s.payload,
+            ''
+        ),
+        payload_size = COALESCE(
+            (SELECT payload_size FROM %(bui)s WHERE
+                batch = :batch AND id = %(bso)s.id),
+            %(bso)s.payload_size,
+            0
+        ),
+        ttl = COALESCE(
+            (SELECT ttl FROM %(bui)s WHERE
+                batch = :batch AND id = %(bso)s.id),
+            %(bso)s.ttl,
+            :default_ttl
+        ),
+        modified = :modified
+    WHERE
+        userid = (
+            SELECT userid FROM batch_uploads WHERE batch = :batch
+        ) AND
+        collection = (
+            SELECT collection FROM batch_uploads WHERE batch = :batch
+        ) AND
+        id IN (
+            SELECT id FROM %(bui)s WHERE batch = :batch
+        )
+"""
+
+APPLY_BATCH_INSERT = """
+    INSERT INTO %(bso)s
+        (userid, collection, id, sortindex, payload,
+        payload_size, ttl, modified)
+    SELECT
+       batch_uploads.userid,
+       batch_uploads.collection,
+       %(bui)s.id,
+       %(bui)s.sortindex,
+       COALESCE(%(bui)s.payload, ''),
+       COALESCE(%(bui)s.payload_size, 0),
+       COALESCE(%(bui)s.ttl, :default_ttl),
+       :modified
+    FROM batch_uploads
+    LEFT JOIN %(bui)s
+    ON
+        %(bui)s.batch = batch_uploads.batch
+    WHERE
+        batch_uploads.batch = :batch AND
+        %(bui)s.id NOT IN (
+            SELECT id
+            FROM %(bso)s
+            WHERE
+                userid = batch_uploads.userid AND
+                collection = batch_uploads.collection
+        )
+"""
 
 CLOSE_BATCH = "DELETE FROM batch_uploads WHERE batch = :batch " \
               "AND userid = :userid AND collection = :collection"

--- a/syncstorage/storage/sql/queries_mysql.py
+++ b/syncstorage/storage/sql/queries_mysql.py
@@ -18,21 +18,30 @@ PURGE_BATCH_CONTENTS = "DELETE FROM %(bui)s " \
                        "WHERE batch < (UNIX_TIMESTAMP() - :grace) * 1000 " \
                        "ORDER BY ttl LIMIT :maxitems"
 
-APPLY_BATCH = "INSERT INTO %(bso)s "\
-                     "  (userid, collection, id, sortindex, modified, "\
-                     "   payload, payload_size, ttl) "\
-                     "SELECT "\
-                     "  :userid, :collection, id, sortindex, :modified, " \
-                     "  COALESCE(payload, \"\"), COALESCE(payload_size, 0), "\
-                     "  COALESCE(ttl, ttl + :default_ttl) "\
-                     "FROM %(bui)s "\
-                     "WHERE batch = :batch "\
-                     "ON DUPLICATE KEY UPDATE "\
-                     "  sortindex = COALESCE(VALUES(sortindex), " \
-                     "                       %(bso)s.sortindex), " \
-                     "  modified = :modified, " \
-                     "  payload = COALESCE(VALUES(payload), " \
-                     "                     %(bso)s.payload), "\
-                     "  payload_size = COALESCE(VALUES(payload_size),"\
-                     "                          %(bso)s.payload_size), "\
-                     "  ttl = COALESCE(VALUES(ttl), %(bso)s.ttl)"
+# MySQL's non-standard ON DUPLICATE KEY UPDATE means we can
+# apply a batch efficiently with a single query.
+
+APPLY_BATCH_UPDATE = None
+
+APPLY_BATCH_INSERT = """
+    INSERT INTO %(bso)s
+        (userid, collection, id, modified, sortindex,
+        ttl, payload, payload_size)
+    SELECT
+        :userid, :collection, id, :modified, sortindex,
+        COALESCE(ttl, :default_ttl),
+        COALESCE(payload, ''),
+        COALESCE(payload_size, 0)
+    FROM %(bui)s
+    WHERE batch = :batch
+    ON DUPLICATE KEY UPDATE
+        modified = :modified,
+        sortindex = COALESCE(%(bui)s.sortindex,
+                             %(bso)s.sortindex),
+        ttl = COALESCE(%(bui)s.ttl,
+                       %(bso)s.ttl),
+        payload = COALESCE(%(bui)s.payload,
+                           %(bso)s.payload),
+        payload_size = COALESCE(%(bui)s.payload_size,
+                                %(bso)s.payload_size)
+"""

--- a/syncstorage/storage/sql/queries_mysql.py
+++ b/syncstorage/storage/sql/queries_mysql.py
@@ -29,7 +29,7 @@ APPLY_BATCH_INSERT = """
         ttl, payload, payload_size)
     SELECT
         :userid, :collection, id, :modified, sortindex,
-        COALESCE(ttl, :default_ttl),
+        COALESCE(ttl_offset + :ttl_base, :default_ttl),
         COALESCE(payload, ''),
         COALESCE(payload_size, 0)
     FROM %(bui)s
@@ -38,7 +38,7 @@ APPLY_BATCH_INSERT = """
         modified = :modified,
         sortindex = COALESCE(%(bui)s.sortindex,
                              %(bso)s.sortindex),
-        ttl = COALESCE(%(bui)s.ttl,
+        ttl = COALESCE(%(bui)s.ttl_offset + :ttl_base,
                        %(bso)s.ttl),
         payload = COALESCE(%(bui)s.payload,
                            %(bso)s.payload),

--- a/syncstorage/storage/sql/queries_sqlite.py
+++ b/syncstorage/storage/sql/queries_sqlite.py
@@ -20,6 +20,8 @@ LOCK_COLLECTION_READ = "SELECT last_modified FROM user_collections "\
 LOCK_COLLECTION_WRITE = "SELECT last_modified FROM user_collections "\
                         "WHERE userid=:userid AND collection=:collectionid"
 
+# Use the correct timestamp-handling functions for sqlite.
+
 PURGE_SOME_EXPIRED_ITEMS = "DELETE FROM %(bso)s "\
                            "WHERE ttl < (strftime('%%s', 'now') - :grace) "
 
@@ -28,3 +30,36 @@ PURGE_BATCHES = "DELETE FROM batch_uploads WHERE batch < " \
 
 PURGE_BATCH_CONTENTS = "DELETE FROM %(bui)s WHERE batch < " \
                        "(SELECT strftime('%%s', 'now') - :grace) * 1000"
+
+# We can use INSERT OR REPLACE to apply a batch in a single query.
+# However, to correctly cope with with partial data udpates, we need
+# to join onto the original table in the SELECT clause so that we
+# can coalesce with the existing values.
+
+APPLY_BATCH_UPDATE = None
+
+APPLY_BATCH_INSERT = """
+    INSERT OR REPLACE INTO %(bso)s
+        (userid, collection, id, sortindex, payload,
+        payload_size, ttl, modified)
+    SELECT
+       batch_uploads.userid,
+       batch_uploads.collection,
+       %(bui)s.id,
+       COALESCE(%(bui)s.sortindex, existing.sortindex),
+       COALESCE(%(bui)s.payload, existing.payload, ''),
+       COALESCE(%(bui)s.payload_size, existing.payload_size, 0),
+       COALESCE(%(bui)s.ttl, existing.ttl, :default_ttl),
+       :modified
+    FROM batch_uploads
+    LEFT JOIN %(bui)s
+    ON
+        %(bui)s.batch = batch_uploads.batch
+    LEFT OUTER JOIN %(bso)s AS existing
+    ON
+        existing.userid = batch_uploads.userid AND
+        existing.collection = batch_uploads.collection AND
+        existing.id = %(bui)s.id
+    WHERE
+        batch_uploads.batch = :batch
+"""

--- a/syncstorage/storage/sql/queries_sqlite.py
+++ b/syncstorage/storage/sql/queries_sqlite.py
@@ -49,7 +49,7 @@ APPLY_BATCH_INSERT = """
        COALESCE(%(bui)s.sortindex, existing.sortindex),
        COALESCE(%(bui)s.payload, existing.payload, ''),
        COALESCE(%(bui)s.payload_size, existing.payload_size, 0),
-       COALESCE(%(bui)s.ttl, existing.ttl, :default_ttl),
+       COALESCE(%(bui)s.ttl_offset + :ttl_base, existing.ttl, :default_ttl),
        :modified
     FROM batch_uploads
     LEFT JOIN %(bui)s

--- a/syncstorage/tests/functional/test_storage.py
+++ b/syncstorage/tests/functional/test_storage.py
@@ -1448,7 +1448,6 @@ class TestStorage(StorageFunctionalTestCase):
         # Fields not touched by the batch, should have been preserved.
         self.assertEquals(res[1]['sortindex'], 17)
 
-    @unittest2.skip("for the moment")
     def test_batch_ttl_update(self):
         collection = self.root + '/storage/col2'
         bsos = [

--- a/syncstorage/tests/functional/test_storage.py
+++ b/syncstorage/tests/functional/test_storage.py
@@ -1484,30 +1484,31 @@ class TestStorage(StorageFunctionalTestCase):
         self.assertEquals(len(res), 1)
         self.assertEquals(res[0]['payload'], 'see')
 
-    @unittest2.skip("for the moment")
     def test_batch_ttl_is_based_on_commit_timestamp(self):
         collection = self.root + '/storage/col2'
 
         resp = self.app.post_json(collection + '?batch=true', [], status=202)
         batch = resp.json["batch"]
         endpoint = collection + '?batch={0}'.format(batch)
-        resp = self.app.post_json(endpoint, [{'id': 'a', 'ttl': 2}],
+        resp = self.app.post_json(endpoint, [{'id': 'a', 'ttl': 3}],
                                   status=202)
 
-        time.sleep(1)
+        # Put some time between upload timestamp and commit timestamp.
+        time.sleep(1.5)
 
         resp = self.app.post_json(endpoint + '&commit=true', [],
                                   status=200)
 
-        # Wait a little; the ttl should not kick in just yet.
-        time.sleep(1.1)
+        # Wait a little; if ttl is taken from the time of the commit
+        # then it should not kick in just yet.
+        time.sleep(1.6)
         resp = self.app.get(collection)
         res = resp.json
         self.assertEquals(len(res), 1)
         self.assertEquals(res[0], 'a')
 
         # Wait some more, and the ttl should kick in.
-        time.sleep(1.1)
+        time.sleep(1.6)
         resp = self.app.get(collection)
         res = resp.json
         self.assertEquals(len(res), 0)

--- a/syncstorage/views/__init__.py
+++ b/syncstorage/views/__init__.py
@@ -297,6 +297,8 @@ def get_collection(request):
 
     if request.validated.get("full", False):
         res = storage.get_items(userid, collection, **filters)
+        for bso in res["items"]:
+            bso.pop("ttl", None)
     else:
         res = storage.get_item_ids(userid, collection, **filters)
     next_offset = res.get("next_offset")
@@ -461,7 +463,9 @@ def get_item(request):
     userid = request.validated["userid"]
     collection = request.validated["collection"]
     item = request.validated["item"]
-    return storage.get_item(userid, collection, item)
+    bso = storage.get_item(userid, collection, item)
+    bso.pop("ttl", None)
+    return bso
 
 
 @item.put(renderer="sync-json",


### PR DESCRIPTION
This fixes the handling of TTL updates in a batch upload, allowing us to unskip the final two testcases for the batch upload work.  See https://bugzilla.mozilla.org/show_bug.cgi?id=1311903.

@Natim r?

It got a little thorny sorry, since it uncovered a bug in the way that the memcache layer was handling TTLs.  It may be easiest to review one commit at a time, and I'll leave some comments below.

The guts of the change is in the third commit, which updates the DB queries to provide proper partial-update semantics:

* If the batch upload did not specify a value of a field, keep any existing value
* Otherwise, use the new value from the batch upload