### PR TITLE
Add a feature-flag for the batch upload feature.

### DIFF
--- a/syncstorage/tests/tests-memcached-cacheonly.ini
+++ b/syncstorage/tests/tests-memcached-cacheonly.ini
@@ -11,6 +11,7 @@ backend = syncstorage.storage.memcached.MemcachedStorage
 wraps = sqlstorage
 cache_key_prefix = sync-${MOZSVC_UUID}-
 cache_only_collections = meta tabs col1 col2
+batch_upload_enabled = true
 
 [sqlstorage]
 backend = syncstorage.storage.sql.SQLStorage

--- a/syncstorage/tests/tests-memcached-writethrough.ini
+++ b/syncstorage/tests/tests-memcached-writethrough.ini
@@ -11,6 +11,7 @@ backend = syncstorage.storage.memcached.MemcachedStorage
 wraps = sqlstorage
 cache_key_prefix = sync-${MOZSVC_UUID}-
 cached_collections = meta tabs col1 col2
+batch_upload_enabled = true
 
 [sqlstorage]
 backend = syncstorage.storage.sql.SQLStorage

--- a/syncstorage/tests/tests-no-batch.ini
+++ b/syncstorage/tests/tests-no-batch.ini
@@ -7,22 +7,15 @@ port = 5000
 use = egg:SyncStorage
 
 [storage]
-backend = syncstorage.storage.memcached.MemcachedStorage
-wraps = sqlstorage
-cache_key_prefix = sync-${MOZSVC_UUID}-
-cached_collections = meta
-cache_only_collections = tabs
-batch_upload_enabled = true
-
-[sqlstorage]
 backend = syncstorage.storage.sql.SQLStorage
 sqluri = ${MOZSVC_SQLURI}
-standard_collections = false
+standard_collections = true
 quota_size = 5242880
 pool_size = 100
 pool_recycle = 3600
 reset_on_return = true
 create_tables = true
+max_post_records = 4000
 
 [hawkauth]
 secret = "TED KOPPEL IS A ROBOT"

--- a/syncstorage/tests/tests-paginated.ini
+++ b/syncstorage/tests/tests-paginated.ini
@@ -15,6 +15,7 @@ pool_size = 100
 pool_recycle = 3600
 reset_on_return = true
 create_tables = true
+batch_upload_enabled = true
 # Use a small batch-size to help test internal pagination usage.
 pagination_batch_size = 4
 

--- a/syncstorage/tests/tests.ini
+++ b/syncstorage/tests/tests.ini
@@ -16,6 +16,7 @@ pool_recycle = 3600
 reset_on_return = true
 create_tables = true
 max_post_records = 4000
+batch_upload_enabled = true
 
 [hawkauth]
 secret = "TED KOPPEL IS A ROBOT"

--- a/syncstorage/views/validators.py
+++ b/syncstorage/views/validators.py
@@ -160,6 +160,12 @@ def extract_batch_state(request):
     If the "commit" parameter is has a value of "true", this batch
     is to be committed and deleted.
     """
+    # Don't extract or validate any of these params
+    # if the batch-upload feature is disabled.
+    settings = request.registry.settings
+    if not settings.get("storage.batch_upload_enabled", False):
+        return
+
     request.validated["batch"] = False
     batch_id = request.GET.get("batch")
     if batch_id is not None:


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1304627

This will let us roll out the new feature slowly, by only enabling it on nodes with the following config:

```
[storage]
batch_upload_enabled = true
```

It will be off by default.  Once we're happy that it's properly deployed in production, we can remove this and have it on all the time.

@Natim r?