### PR TITLE
Enable and change behaviour of disabled batch tests

### DIFF
--- a/syncstorage/tests/functional/test_storage.py
+++ b/syncstorage/tests/functional/test_storage.py
@@ -1448,7 +1448,6 @@ class TestStorage(StorageFunctionalTestCase):
         # Fields not touched by the batch, should have been preserved.
         self.assertEquals(res[1]['sortindex'], 17)
 
-    @unittest2.skip("for the moment")
     def test_batch_ttl_update(self):
         collection = self.root + '/storage/col2'
         bsos = [
@@ -1459,13 +1458,11 @@ class TestStorage(StorageFunctionalTestCase):
         resp = self.app.post_json(collection, bsos)
 
         # Bump ttls as a series of individual batch operations.
-        resp = self.app.post_json(collection + '?batch=true', [], status=202)
+        resp = self.app.post_json(collection + '?batch=true', [])
         batch = resp.json["batch"]
         endpoint = collection + '?batch={0}'.format(batch)
-        resp = self.app.post_json(endpoint, [{'id': 'a', 'ttl': 2}],
-                                  status=202)
-        resp = self.app.post_json(endpoint, [{'id': 'b', 'ttl': 2}],
-                                  status=202)
+        resp = self.app.post_json(endpoint, [{'id': 'a', 'ttl': 2}])
+        resp = self.app.post_json(endpoint, [{'id': 'b', 'ttl': 2}])
         resp = self.app.post_json(endpoint + '&commit=true', [],
                                   status=200)
 
@@ -1485,15 +1482,13 @@ class TestStorage(StorageFunctionalTestCase):
         self.assertEquals(len(res), 1)
         self.assertEquals(res[0]['payload'], 'see')
 
-    @unittest2.skip("for the moment")
     def test_batch_ttl_is_based_on_commit_timestamp(self):
         collection = self.root + '/storage/col2'
 
-        resp = self.app.post_json(collection + '?batch=true', [], status=202)
+        resp = self.app.post_json(collection + '?batch=true', [])
         batch = resp.json["batch"]
         endpoint = collection + '?batch={0}'.format(batch)
-        resp = self.app.post_json(endpoint, [{'id': 'a', 'ttl': 2}],
-                                  status=202)
+        resp = self.app.post_json(endpoint, [{'id': 'a', 'ttl': 2}])
 
         time.sleep(1)
 


### PR DESCRIPTION
- enable test_batch_ttl_update
- enable test_batch_ttl_is_based_on_commit_timestamp
- change to check for 200 status instead of 202 (Accepted) from
  batch API

Let's discuss the change from 202 (Accepted) to 200. I think 200 are actually the right response code for the API to return. A 202 responses means the request was accepted but has not finished processing. That's not accurate because the data has already been written to disk and there nothing further to do. Committing the batch will be another discrete operation. 

@rtilder @rfk r?