### PR TITLE
Don't try to purge batch_upload_items in ttl order.

### DIFF
--- a/syncstorage/storage/sql/queries_mysql.py
+++ b/syncstorage/storage/sql/queries_mysql.py
@@ -16,7 +16,7 @@ PURGE_SOME_EXPIRED_ITEMS = "DELETE FROM %(bso)s "\
 
 PURGE_BATCH_CONTENTS = "DELETE FROM %(bui)s " \
                        "WHERE batch < (UNIX_TIMESTAMP() - :grace) * 1000 " \
-                       "ORDER BY ttl LIMIT :maxitems"
+                       "ORDER BY batch LIMIT :maxitems"
 
 # MySQL's non-standard ON DUPLICATE KEY UPDATE means we can
 # apply a batch efficiently with a single query.


### PR DESCRIPTION
The ttls in that table are offests, and the batch ids are timestamps.  It makes more sense to order by batch id so that we're pruning an entire left subtree of the primary key.

@Natim r?