### PR TITLE
Add tests to ensure users can't write to each other's batches.

### DIFF
--- a/syncstorage/storage/memcached.py
+++ b/syncstorage/storage/memcached.py
@@ -971,7 +971,9 @@ class CacheOnlyManager(_CachedManagerBase):
         batchid = str(batch)
         bdata, bcasid = self.get_cached_batches(userid)
 
-        if batchid not in bdata or bdata[batchid]["expires"] < ts:
+        if not bdata or batchid not in bdata:
+            return False
+        if bdata[batchid]["expires"] < ts:
             self.close_batch(userid, batchid)
             return False
         return True
@@ -1012,11 +1014,10 @@ class CacheOnlyManager(_CachedManagerBase):
         bdata, bcasid = self.get_cached_batches(userid)
         key = self.get_batches_key(userid)
 
-        if batchid in bdata:
-            try:
-                del bdata[batchid]
-            except KeyError:
-                return
+        try:
+            del bdata[batchid]
+        except KeyError:
+            return
         if not self.cache.cas(key, bdata, bcasid):
             raise ConflictError
 


### PR DESCRIPTION
The tests pass without any changes to the code, but it's nice
to have them explicit, especially since the batchid provides
a layer of indirection when writing to a collection.

@Natim r?