### PR TITLE
Make batch and non-batch posts have same semantics for invalid items.

### DIFF
--- a/syncstorage/bso.py
+++ b/syncstorage/bso.py
@@ -69,6 +69,11 @@ class BSO(dict):
             try:
                 if not VALID_ID_REGEX.match(value):
                     return False, 'invalid id'
+                # A regex like /^[blah]$/ can happily match a string
+                # with a trailing newline because of how the '$' is
+                # interpreted.  Guard against it explicitly.
+                if value[-1] == '\n':
+                    return False, 'invalid id'
             except TypeError:
                 return False, 'invalid id'
             # Make sure it's stored as a bytestring, not a unicode object.

--- a/syncstorage/views/__init__.py
+++ b/syncstorage/views/__init__.py
@@ -368,16 +368,10 @@ def post_collection_batch(request):
     # The "batch" key is set only on a multi-POST batch request prior to a
     # commit.  The "modified" key is only set upon a successful commit.
     # The two flags are mutually exclusive.
-    # Any failures at all mean cancelling the batch completely.
     res = {'success': [], 'failed': {}}
 
-    # If there are any parsing failures, we won't even start a batch.
-    if len(invalid_bsos):
-        for (id, error) in invalid_bsos.iteritems():
-            res["failed"][id] = error
-        # if batch and batch is not True:
-        #     storage.delete_batch(batch)
-        return res
+    for (id, error) in invalid_bsos.iteritems():
+        res["failed"][id] = error
 
     try:
         if batch is True:
@@ -401,33 +395,32 @@ def post_collection_batch(request):
         if bsos:
             try:
                 storage.append_items_to_batch(userid, collection, batch, bsos)
-                res["success"].extend([bso["id"] for bso in bsos])
             except ConflictError:
                 raise
             except Exception, e:
                 logger.error('Could not append to batch("{0}")'.format(batch))
-                logger.error(str(e))
+                logger.error(e)
                 for bso in bsos:
                     res["failed"][bso["id"]] = "db error"
-                raise
+            else:
+                res["success"].extend([bso["id"] for bso in bsos])
 
         if commit:
             try:
                 ts = storage.apply_batch(userid, collection, batch)
-                res['modified'] = ts
-                request.response.headers["X-Last-Modified"] = str(ts)
-                storage.close_batch(userid, collection, batch)
-                request.response.status = 200
-            except ConflictError:
-                for bso in bsos:
-                    res["failed"][bso["id"]] = "db error: commit"
+            except ConflictError, e:
+                logger.error('Collision in batch commit!')
+                logger.error(e)
                 raise
             except Exception, e:
                 logger.error("Could not apply batch")
                 logger.error(e)
-                for bso in bsos:
-                    res["failed"][bso["id"]] = "db error: commit"
                 raise
+            else:
+                res['modified'] = ts
+                request.response.headers["X-Last-Modified"] = str(ts)
+                storage.close_batch(userid, collection, batch)
+                request.response.status = 200
         else:
             res["batch"] = b64encode(str(batch))
     except ConflictError:


### PR DESCRIPTION
In the non-batch case, we ignore individual invalid items and continue with processing the valid ones.  Since we want the semantics of batch uploads to be as close to non-batch as possible, we should apply the same rules there.

For a fun bonus, this uncovered an edge-case where we'd incorrectly accept a BSO id with a trailing newline, because regexes.