### PR TITLE
Fix test_batch_with_failing_bsos commit logic

### DIFF
--- a/syncstorage/tests/functional/test_storage.py
+++ b/syncstorage/tests/functional/test_storage.py
@@ -1575,7 +1575,7 @@ class TestStorage(StorageFunctionalTestCase):
         endpoint = collection + '?batch={0}&commit=true'.format(batch)
         resp = self.app.post_json(endpoint, bsos)
         self.assertEqual(len(resp.json['failed']), 1)
-        self.assertEqual(len(resp.json['success']), 1)
+        self.assertEqual(len(resp.json['success']), 2)
 
         # To correctly match semantics of batchless POST, the batch
         # should be committed including only the successful items.


### PR DESCRIPTION
When the batch is committed the success criteria should be be 2
successful BSOs not 1. BSOs ["a", "c"] are committed so the "success" key
should account for both of them.

@rfk r? Please 