### PR TITLE
Bug 1314171 - Reintroduce the 'older' query parameter.

### DIFF
--- a/syncstorage/storage/__init__.py
+++ b/syncstorage/storage/__init__.py
@@ -212,7 +212,7 @@ class SyncStorage(object):
 
     @abc.abstractmethod
     def get_items(self, userid, collection, items=None, newer=None,
-                  limit=None, offset=None, sort=None):
+                  older=None, limit=None, offset=None, sort=None):
         """Returns items from a collection
 
         Args:
@@ -220,6 +220,7 @@ class SyncStorage(object):
             collection: name of the collection.
             items: list of strings identifying items to return.
             newer: float; only return items newer than this timestamp.
+            older: float; only return items older than this timestamp.
             limit: integer; return at most this many items.
             offset: string; an offset vale previously returned as next_offset.
             sort: sort order for results; one of "newest", "oldest" or "index".
@@ -236,7 +237,7 @@ class SyncStorage(object):
 
     @abc.abstractmethod
     def get_item_ids(self, userid, collection, items=None, newer=None,
-                     limit=None, offset=None, sort=None):
+                     older=None, limit=None, offset=None, sort=None):
         """Returns item ids from a collection
 
         Args:
@@ -244,6 +245,7 @@ class SyncStorage(object):
             collection: name of the collection.
             items: list of strings identifying items to return.
             newer: float; only return items newer than this timestamp.
+            older: float; only return items older than this timestamp.
             limit: integer; return at most this many items.
             offset: string; an offset vale previously returned as next_offset.
             sort: sort order for results; one of "newest", "oldest" or "index".

--- a/syncstorage/storage/memcached.py
+++ b/syncstorage/storage/memcached.py
@@ -760,6 +760,7 @@ class _CachedManagerBase(object):
     def get_items(self, userid, **kwds):
         # Decode kwds into individual filter values.
         newer = kwds.pop("newer", None)
+        older = kwds.pop("older", None)
         limit = kwds.pop("limit", None)
         offset = kwds.pop("offset", None)
         sort = kwds.pop("sort", None)
@@ -779,6 +780,8 @@ class _CachedManagerBase(object):
         # Apply the various filters as generator expressions.
         if newer is not None:
             bsos = (bso for bso in bsos if bso["modified"] > newer)
+        if older is not None:
+            bsos = (bso for bso in bsos if bso["modified"] < older)
         # Filter out any that have expired.
         bsos = self._filter_expired_items(bsos)
         # Sort the resulting list.

--- a/syncstorage/storage/sql/__init__.py
+++ b/syncstorage/storage/sql/__init__.py
@@ -336,6 +336,8 @@ class SQLStorage(SyncStorage):
             params["ttl"] = int(session.timestamp)
         if "newer" in params:
             params["newer"] = ts2bigint(params["newer"])
+        if "older" in params:
+            params["older"] = ts2bigint(params["older"])
         # We always fetch one more item than necessary, so we can tell whether
         # there are additional items to be fetched with next_offset.
         limit = params.get("limit")
@@ -431,6 +433,9 @@ class SQLStorage(SyncStorage):
                 bound, offset = map(int, offset.split(":", 1))
                 # Queries with "newer" should always produce bound > newer
                 if bound < params.get("newer", bound):
+                    raise InvalidOffsetError(offset)
+                # Queries with "older" should always produce bound < older
+                if bound > params.get("older", bound):
                     raise InvalidOffsetError(offset)
                 # The bound determines the starting point of the sort order.
                 params["offset"] = offset

--- a/syncstorage/storage/sql/queries_generic.py
+++ b/syncstorage/storage/sql/queries_generic.py
@@ -115,6 +115,8 @@ def FIND_ITEMS(bso, params):
         query = query.where(bso.c.modified > bindparam("newer"))
     if "newer_eq" in params:
         query = query.where(bso.c.modified >= bindparam("newer_eq"))
+    if "older" in params:
+        query = query.where(bso.c.modified < bindparam("older"))
     if "older_eq" in params:
         query = query.where(bso.c.modified <= bindparam("older_eq"))
     if "ttl" in params:

--- a/syncstorage/views/__init__.py
+++ b/syncstorage/views/__init__.py
@@ -265,7 +265,7 @@ def get_collection(request):
     collection = request.validated["collection"]
 
     filters = {}
-    filter_names = ("ids", "newer", "limit", "offset", "sort")
+    filter_names = ("ids", "newer", "older", "limit", "offset", "sort")
     for name in filter_names:
         if name in request.validated:
             filters[name] = request.validated[name]

--- a/syncstorage/views/validators.py
+++ b/syncstorage/views/validators.py
@@ -85,6 +85,7 @@ def extract_query_params(request):
     This validator will extract and validate the following search params:
 
         * newer: lower-bound on last-modified time (float timestamp)
+        * older: upper-bound on last-modified time (float timestamp)
         * sort:  order in which to return results (string)
         * limit:  maximum number of items to return (integer)
         * offset:  position at which to restart search (string)
@@ -103,6 +104,18 @@ def extract_query_params(request):
             request.errors.add("querystring", "newer", msg)
         else:
             request.validated["newer"] = newer
+
+    older = request.GET.get("older")
+    if older is not None:
+        try:
+            older = get_timestamp(older)
+            if older < 0:
+                raise ValueError
+        except ValueError:
+            msg = "Invalid value for older: %r" % (older,)
+            request.errors.add("querystring", "older", msg)
+        else:
+            request.validated["older"] = older
 
     limit = request.GET.get("limit")
     if limit is not None:


### PR DESCRIPTION
This was removed in sync 1.5 because clients weren't using it, but we've found a use-case for it now and there's basically no cost to bringing it back.  See https://bugzilla.mozilla.org/show_bug.cgi?id=1314171 for details.

@Natim r?  And don't worry, soon I'll go back to not having time for significant syncstorage work :-)