### PR TITLE
Skip user-switching functional tests when running them live.

### DIFF
--- a/syncstorage/storage/sql/queries_generic.py
+++ b/syncstorage/storage/sql/queries_generic.py
@@ -234,6 +234,7 @@ def FIND_ITEMS(bso, params):
         query = query.offset(offset)
     return query
 
+
 # Queries operating on a particular item.
 
 DELETE_ITEM = "DELETE FROM %(bso)s WHERE userid=:userid AND "\

--- a/syncstorage/tests/test_memcachedsql.py
+++ b/syncstorage/tests/test_memcachedsql.py
@@ -299,5 +299,6 @@ def test_suite():
         suite.addTest(unittest2.makeSuite(TestMemcachedSQLStorage))
     return suite
 
+
 if __name__ == "__main__":
     unittest2.main(defaultTest="test_suite")


### PR DESCRIPTION
This issue was causing test failures when updating https://github.com/mozilla-services/syncserver to the latest tag.  Since it's only tests and lint, merging r=myself to fix the tests.