### PR TITLE
Add a functional test for expected behaviour when ttl=null

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,18 +16,17 @@ dependencies:
     # Create a version.json file for the app to serve; copy it to the CircleCI
     # artifacts directory for debugging.
     - >
-        printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' 
-        "$CIRCLE_SHA1" 
+        printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n'
+        "$CIRCLE_SHA1"
         "$CIRCLE_TAG"
-        "$CIRCLE_PROJECT_USERNAME" 
-        "$CIRCLE_PROJECT_REPONAME" 
+        "$CIRCLE_PROJECT_USERNAME"
+        "$CIRCLE_PROJECT_REPONAME"
         "$CIRCLE_BUILD_URL"
         > version.json
     - cp version.json $CIRCLE_ARTIFACTS
 
     # build the actual deployment container
     - docker build -t app:build .
-    - docker images --no-trunc | awk '/^app/ {print $3}' | tee $CIRCLE_ARTIFACTS/docker-image-shasum256.txt
 
     # Clean up any old images; save the new one.
     - I="image-$(date +%j).tgz"; mkdir -p ~/docker; rm ~/docker/*; docker save app:build | pigz --fast -c > ~/docker/$I; ls -l ~/docker

--- a/syncstorage/tests/functional/test_storage.py
+++ b/syncstorage/tests/functional/test_storage.py
@@ -1749,6 +1749,14 @@ class TestStorage(StorageFunctionalTestCase):
         self.assertEquals(res[2]['payload'], 'cee')
         self.assertEquals(res[3]['payload'], 'di')
 
+    # bug 1332552 make sure ttl:null use the default ttl
+    def test_create_bso_with_null_ttl(self):
+        bso = {"payload": "x", "ttl": None}
+        self.app.put_json(self.root + "/storage/col2/TEST1", bso)
+        time.sleep(0.1)
+        res = self.app.get(self.root + "/storage/col2/TEST1?full=1")
+        self.assertEquals(res.json["payload"], "x")
+
 
 class TestStorageMemcached(TestStorage):
     """Storage testcases run against the memcached backend, if available."""


### PR DESCRIPTION
Ref: [Bug 1332552](https://bugzilla.mozilla.org/show_bug.cgi?id=1332552). iOS clients send a ttl:null for BSOs in the JSON. This
is meant to be interpreted as never expire. The gosync server doesn't
behave correctly with ttl=null. Add a test to prevent regressions.

@rfk r? please