### PR TITLE
Use module name as logger names

### DIFF
--- a/syncstorage/scripts/__init__.py
+++ b/syncstorage/scripts/__init__.py
@@ -50,7 +50,7 @@ def configure_script_logging(opts=None):
     handler = logging.StreamHandler()
     handler.setFormatter(logging.Formatter("%(message)s"))
     handler.setLevel(loglevel)
-    logger = logging.getLogger("")
+    logger = logging.getLogger(__name__)
     logger.addHandler(handler)
     logger.setLevel(loglevel)
 

--- a/syncstorage/scripts/mcclear.py
+++ b/syncstorage/scripts/mcclear.py
@@ -23,7 +23,7 @@ from syncstorage.storage.memcached import MemcachedStorage
 from syncstorage.scripts.mcread import maybe_open
 
 
-logger = logging.getLogger("syncstorage.scripts.mcclear")
+logger = logging.getLogger(__name__)
 
 
 def clear_memcache_data(config_file, input_file):

--- a/syncstorage/scripts/mcread.py
+++ b/syncstorage/scripts/mcread.py
@@ -22,7 +22,7 @@ from syncstorage.storage import get_all_storages
 from syncstorage.storage.memcached import MemcachedStorage
 
 
-logger = logging.getLogger("syncstorage.scripts.mcread")
+logger = logging.getLogger(__name__)
 
 
 def read_memcache_data(config_file, input_file, output_file):

--- a/syncstorage/scripts/purgettl.py
+++ b/syncstorage/scripts/purgettl.py
@@ -22,7 +22,7 @@ import syncstorage.scripts
 from syncstorage.storage import get_all_storages
 
 
-logger = logging.getLogger("syncstorage.scripts.prunettl")
+logger = logging.getLogger(__name__)
 
 
 def purge_expired_items(config_file, grace_period=0, max_per_loop=1000,

--- a/syncstorage/storage/__init__.py
+++ b/syncstorage/storage/__init__.py
@@ -14,7 +14,7 @@ import logging
 from mozsvc.plugin import resolve_name
 
 
-logger = logging.getLogger("syncstorage.storage")
+logger = logging.getLogger(__name__)
 
 # Rough guesstimate of the maximum reasonable life span of a batch.
 BATCH_LIFETIME = 60 * 60 * 2  # 2 hours, in seconds

--- a/syncstorage/storage/sql/__init__.py
+++ b/syncstorage/storage/sql/__init__.py
@@ -39,7 +39,7 @@ from syncstorage.storage.sql.dbconnect import (DBConnector, MAX_TTL,
 from mozsvc.metrics import metrics_timer
 
 
-logger = logging.getLogger("syncstorage.storage.sql")
+logger = logging.getLogger(__name__)
 
 # For efficiency, it's possible to use fixed pre-determined IDs for
 # common collection names.  This is the canonical list of such names.

--- a/syncstorage/storage/sql/dbconnect.py
+++ b/syncstorage/storage/sql/dbconnect.py
@@ -46,7 +46,7 @@ from syncstorage.storage.sql import (queries_generic,
                                      queries_mysql)
 
 
-logger = logging.getLogger("syncstorage.storage.sql")
+logger = logging.getLogger(__name__)
 
 # Regex to match safe database field/column names.
 SAFE_FIELD_NAME_RE = re.compile("^[a-zA-Z0-9_]+$")

--- a/syncstorage/views/__init__.py
+++ b/syncstorage/views/__init__.py
@@ -30,7 +30,7 @@ from syncstorage.views.decorators import (convert_storage_errors,
 from syncstorage.views.util import get_resource_timestamp, get_limit_config
 
 
-logger = logging.getLogger("syncstorage")
+logger = logging.getLogger(__name__)
 
 DEFAULT_VALIDATORS = (
     extract_target_resource,

--- a/syncstorage/views/authentication.py
+++ b/syncstorage/views/authentication.py
@@ -13,7 +13,7 @@ from pyramid.interfaces import IAuthenticationPolicy
 from mozsvc.user import TokenServerAuthenticationPolicy
 
 
-logger = logging.getLogger("syncstorage")
+logger = logging.getLogger(__name__)
 
 
 DEFAULT_EXPIRED_TOKEN_TIMEOUT = 60 * 60 * 2  # 2 hours, in seconds

--- a/syncstorage/views/decorators.py
+++ b/syncstorage/views/decorators.py
@@ -20,7 +20,7 @@ from syncstorage.views.util import (make_decorator,
                                     json_error,
                                     get_resource_timestamp)
 
-logger = logging.getLogger("syncstorage")
+logger = logging.getLogger(__name__)
 
 ONE_KB = 1024
 ONE_MB = 1024 * 1024

--- a/syncstorage/views/validators.py
+++ b/syncstorage/views/validators.py
@@ -2,8 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import logging
 import re
-
 from base64 import b64decode
 
 from syncstorage.bso import BSO, VALID_ID_REGEX
@@ -11,8 +11,8 @@ from syncstorage.util import get_timestamp, json_loads
 from syncstorage.storage import get_storage
 from syncstorage.views.util import json_error, get_limit_config
 
-import logging
-logger = logging.getLogger("syncstorage.views.validators")
+
+logger = logging.getLogger(__name__)
 
 
 BATCH_MAX_IDS = 100


### PR DESCRIPTION
Using MozLog the logger name provides some general context about the
source of the log event.

These changes will keep the logger names as before, except for the following
cases:

- ``syncstorage.scripts.prunettl`` →  ``syncstorage.scripts.purgettl``
- ``syncstorage.storage.sql`` →  ``syncstorage.storage.sql.dbconnect``
- ``syncstorage`` →  ``syncstorage.views``
- ``syncstorage`` →  ``syncstorage.views.authentication``
- ``syncstorage`` →  ``syncstorage.views.decorators``

See also:

* MozLog v2 in Sync https://bugzilla.mozilla.org/show_bug.cgi?id=1340674
* Related mozilla-services/mozservices#38

@rfk r?