### PR TITLE
Bug 1345742 - don't intermingle batch uploads from multiple users.

### DIFF
--- a/syncstorage/storage/sql/__init__.py
+++ b/syncstorage/storage/sql/__init__.py
@@ -520,7 +520,7 @@ class SQLStorage(SyncStorage):
         rows = []
         for data in items:
             id_ = data["id"]
-            row = self._prepare_bui_row(session, batchid, id_, data)
+            row = self._prepare_bui_row(session, batchid, userid, id_, data)
             rows.append(row)
         session.insert_or_update("batch_upload_items", rows)
         return session.timestamp
@@ -668,9 +668,10 @@ class SQLStorage(SyncStorage):
                 row["ttl"] = data["ttl"] + int(session.timestamp)
         return row
 
-    def _prepare_bui_row(self, session, batchid, item, data):
+    def _prepare_bui_row(self, session, batchid, userid, item, data):
         row = {}
         row["batch"] = batchid
+        row["userid"] = userid
         row["id"] = item
         if "sortindex" in data:
             row["sortindex"] = data["sortindex"]

--- a/syncstorage/storage/sql/dbconnect.py
+++ b/syncstorage/storage/sql/dbconnect.py
@@ -170,6 +170,8 @@ def _get_batch_item_columns(table_name):
     return (
         Column("batch", BigInteger, primary_key=True, nullable=False,
                autoincrement=False),
+        Column("userid", Integer, primary_key=True, nullable=False,
+               autoincrement=False),
         Column("id", String(64), primary_key=True, nullable=False,
                autoincrement=False),
         # All these need to be nullable, because the batch upload

--- a/syncstorage/storage/sql/queries_mysql.py
+++ b/syncstorage/storage/sql/queries_mysql.py
@@ -43,7 +43,7 @@ APPLY_BATCH_INSERT = """
         COALESCE(payload, ''),
         COALESCE(payload_size, 0)
     FROM %(bui)s
-    WHERE batch = :batch
+    WHERE batch = :batch AND userid = :userid
     ON DUPLICATE KEY UPDATE
         modified = :modified,
         sortindex = COALESCE(%(bui)s.sortindex,

--- a/syncstorage/storage/sql/queries_sqlite.py
+++ b/syncstorage/storage/sql/queries_sqlite.py
@@ -60,12 +60,14 @@ APPLY_BATCH_INSERT = """
     FROM batch_uploads
     LEFT JOIN %(bui)s
     ON
-        %(bui)s.batch = batch_uploads.batch
+        %(bui)s.batch = batch_uploads.batch AND
+        %(bui)s.userid = batch_uploads.userid
     LEFT OUTER JOIN %(bso)s AS existing
     ON
         existing.userid = batch_uploads.userid AND
         existing.collection = batch_uploads.collection AND
         existing.id = %(bui)s.id
     WHERE
-        batch_uploads.batch = :batch
+        batch_uploads.batch = :batch AND
+        batch_uploads.userid = :userid
 """


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1345742

This adds an explicit "userid" column to the batch-upload-items table, so that we don't risk intermingling data uploaded by different users. @Natim r?