### PR TITLE
Bug 1388963 - Remove use of UNIX_TIMESTAMP() in queries.

### DIFF
--- a/syncstorage/storage/sql/__init__.py
+++ b/syncstorage/storage/sql/__init__.py
@@ -807,6 +807,7 @@ class SQLStorage(SyncStorage):
         # This avoids holdig open a long-running transaction, so
         # the incrementality can let other jobs run properly.
         with self._get_or_create_session() as session:
+            params["now"] = int(session.timestamp)
             rowcount = session.query(query, params)
         while rowcount > 0:
             num_purged += rowcount

--- a/syncstorage/storage/sql/queries_generic.py
+++ b/syncstorage/storage/sql/queries_generic.py
@@ -266,15 +266,15 @@ ITEM_TIMESTAMP = "SELECT modified FROM %(bso)s "\
 
 PURGE_SOME_EXPIRED_ITEMS = """
     DELETE FROM %(bso)s
-    WHERE ttl < (UNIX_TIMESTAMP() - :grace)
+    WHERE ttl < (:now - :grace)
 """
 
 PURGE_BATCHES = """
     DELETE FROM batch_uploads
-    WHERE batch < (UNIX_TIMESTAMP() - :lifetime - :grace) * 1000
+    WHERE batch < (:now - :lifetime - :grace) * 1000
 """
 
 PURGE_BATCH_CONTENTS = """
     DELETE FROM %(bui)s
-    WHERE batch < (UNIX_TIMESTAMP() - :lifetime - :grace) * 1000
+    WHERE batch < (:now - :lifetime - :grace) * 1000
 """

--- a/syncstorage/storage/sql/queries_mysql.py
+++ b/syncstorage/storage/sql/queries_mysql.py
@@ -12,19 +12,19 @@ tailored to MySQL.
 
 PURGE_SOME_EXPIRED_ITEMS = """
     DELETE FROM %(bso)s
-    WHERE ttl < (UNIX_TIMESTAMP() - :grace)
+    WHERE ttl < (:now - :grace)
     ORDER BY ttl LIMIT :maxitems
 """
 
 PURGE_BATCHES = """
     DELETE FROM batch_uploads
-    WHERE batch < (UNIX_TIMESTAMP() - :lifetime - :grace) * 1000
+    WHERE batch < (:now - :lifetime - :grace) * 1000
     ORDER BY batch LIMIT :maxitems
 """
 
 PURGE_BATCH_CONTENTS = """
     DELETE FROM %(bui)s
-    WHERE batch < (UNIX_TIMESTAMP() - :lifetime - :grace) * 1000
+    WHERE batch < (:now - :lifetime - :grace) * 1000
     ORDER BY batch LIMIT :maxitems
 """
 

--- a/syncstorage/storage/sql/queries_postgres.py
+++ b/syncstorage/storage/sql/queries_postgres.py
@@ -53,25 +53,3 @@ END IF;
 END;
 $do$;
 """.strip()
-
-
-# Use correct timestamp functions for postgres.
-
-PURGE_SOME_EXPIRED_ITEMS = """
-    DELETE FROM %(bso)s
-    WHERE ttl < (EXTRACT(EPOCH FROM CURRENT_TIMESTAMP) - :grace)
-"""
-
-PURGE_BATCHES = """
-    DELETE FROM batch_uploads
-    WHERE batch < (
-        SELECT EXTRACT(EPOCH FROM CURRENT_TIMSTAMP) - :lifetime - :grace
-    ) * 1000
-"""
-
-PURGE_BATCH_CONTENTS = """
-    DELETE FROM %(bui)s
-    WHERE batch < (
-        SELECT EXTRACT(EPOCH FROM CURRENT_TIMSTAMP) - :lifetime - :grace
-    ) * 1000
-"""

--- a/syncstorage/storage/sql/queries_sqlite.py
+++ b/syncstorage/storage/sql/queries_sqlite.py
@@ -20,23 +20,6 @@ LOCK_COLLECTION_READ = "SELECT last_modified FROM user_collections "\
 LOCK_COLLECTION_WRITE = "SELECT last_modified FROM user_collections "\
                         "WHERE userid=:userid AND collection=:collectionid"
 
-# Use the correct timestamp-handling functions for sqlite.
-
-PURGE_SOME_EXPIRED_ITEMS = """
-    DELETE FROM %(bso)s
-    WHERE ttl < (strftime('%%s', 'now') - :grace)
-"""
-
-PURGE_BATCHES = """
-    DELETE FROM batch_uploads
-    WHERE batch < (strftime('%s', 'now') - :lifetime - :grace) * 1000
-"""
-
-PURGE_BATCH_CONTENTS = """
-    DELETE FROM %(bui)s
-    WHERE batch < (strftime('%%s', 'now') - :lifetime - :grace) * 1000
-"""
-
 # We can use INSERT OR REPLACE to apply a batch in a single query.
 # However, to correctly cope with with partial data udpates, we need
 # to join onto the original table in the SELECT clause so that we


### PR DESCRIPTION
We found that this can prevent MySQL from using an index in some circumstances, so instead let's pass in a timestamp from the application.