### PR TITLE
Bug 1397357 Handling empty batch commit messages

### DIFF
--- a/syncstorage/tests/functional/test_storage.py
+++ b/syncstorage/tests/functional/test_storage.py
@@ -1924,6 +1924,7 @@ class TestStorage(StorageFunctionalTestCase):
         testEmptyCommit("application/newlines", "{}", status=400)
         testEmptyCommit("application/newlines", "[]", status=400)
 
+
 class TestStorageMemcached(TestStorage):
     """Storage testcases run against the memcached backend, if available."""
 

--- a/syncstorage/tests/functional/test_storage.py
+++ b/syncstorage/tests/functional/test_storage.py
@@ -1916,8 +1916,8 @@ class TestStorage(StorageFunctionalTestCase):
             )
 
         testEmptyCommit("application/json", "")
+        testEmptyCommit("application/json", "[]")
         testEmptyCommit("application/json", "{}")
-        testEmptyCommit("application/json", "", status=400)
 
         testEmptyCommit("application/newlines", "")
         testEmptyCommit("application/newlines", "\n", status=400)

--- a/syncstorage/tests/functional/test_storage.py
+++ b/syncstorage/tests/functional/test_storage.py
@@ -1901,6 +1901,28 @@ class TestStorage(StorageFunctionalTestCase):
         self.app.put_json(self.root + "/storage/col2/keys", bso, status=200)
         self.app.post_json(self.root + "/storage/col2", [bso], status=200)
 
+    # bug 1397357
+    def test_batch_empty_commit(self):
+        def testEmptyCommit(contentType, body, status=200):
+            bsos = [{'id': str(i), 'payload': 'X'} for i in range(5)]
+            res = self.app.post_json(self.root+'/storage/col?batch=true', bsos)
+            self.assertEquals(len(res.json['success']), 5)
+            self.assertEquals(len(res.json['failed']), 0)
+            batch = res.json["batch"]
+            self.app.post(
+                self.root+'/storage/col?commit=true&batch='+batch,
+                body, headers={"Content-Type": contentType},
+                status=status
+            )
+
+        testEmptyCommit("application/json", "")
+        testEmptyCommit("application/json", "{}")
+        testEmptyCommit("application/json", "", status=400)
+
+        testEmptyCommit("application/newlines", "")
+        testEmptyCommit("application/newlines", "\n", status=400)
+        testEmptyCommit("application/newlines", "{}", status=400)
+        testEmptyCommit("application/newlines", "[]", status=400)
 
 class TestStorageMemcached(TestStorage):
     """Storage testcases run against the memcached backend, if available."""


### PR DESCRIPTION
- API should only accept specific empty bodies depending on the
  Content-Type
- Invalid empty POST bodies should respond with a 400 Bad Request