### PR TITLE
Empty request body should be valid applicatiln/newlines input

### DIFF
--- a/syncstorage/tests/functional/test_storage.py
+++ b/syncstorage/tests/functional/test_storage.py
@@ -1924,6 +1924,7 @@ class TestStorage(StorageFunctionalTestCase):
         testEmptyCommit("application/newlines", "{}", status=400)
         testEmptyCommit("application/newlines", "[]", status=400)
 
+
 class TestStorageMemcached(TestStorage):
     """Storage testcases run against the memcached backend, if available."""
 

--- a/syncstorage/tests/functional/test_storage.py
+++ b/syncstorage/tests/functional/test_storage.py
@@ -1916,8 +1916,8 @@ class TestStorage(StorageFunctionalTestCase):
             )
 
         testEmptyCommit("application/json", "")
+        testEmptyCommit("application/json", "[]")
         testEmptyCommit("application/json", "{}")
-        testEmptyCommit("application/json", "", status=400)
 
         testEmptyCommit("application/newlines", "")
         testEmptyCommit("application/newlines", "\n", status=400)

--- a/syncstorage/tests/functional/test_storage.py
+++ b/syncstorage/tests/functional/test_storage.py
@@ -1901,6 +1901,28 @@ class TestStorage(StorageFunctionalTestCase):
         self.app.put_json(self.root + "/storage/col2/keys", bso, status=200)
         self.app.post_json(self.root + "/storage/col2", [bso], status=200)
 
+    # bug 1397357
+    def test_batch_empty_commit(self):
+        def testEmptyCommit(contentType, body, status=200):
+            bsos = [{'id': str(i), 'payload': 'X'} for i in range(5)]
+            res = self.app.post_json(self.root+'/storage/col?batch=true', bsos)
+            self.assertEquals(len(res.json['success']), 5)
+            self.assertEquals(len(res.json['failed']), 0)
+            batch = res.json["batch"]
+            self.app.post(
+                self.root+'/storage/col?commit=true&batch='+batch,
+                body, headers={"Content-Type": contentType},
+                status=status
+            )
+
+        testEmptyCommit("application/json", "")
+        testEmptyCommit("application/json", "{}")
+        testEmptyCommit("application/json", "", status=400)
+
+        testEmptyCommit("application/newlines", "")
+        testEmptyCommit("application/newlines", "\n", status=400)
+        testEmptyCommit("application/newlines", "{}", status=400)
+        testEmptyCommit("application/newlines", "[]", status=400)
 
 class TestStorageMemcached(TestStorage):
     """Storage testcases run against the memcached backend, if available."""

--- a/syncstorage/tests/functional/test_storage.py
+++ b/syncstorage/tests/functional/test_storage.py
@@ -1915,9 +1915,9 @@ class TestStorage(StorageFunctionalTestCase):
                 status=status
             )
 
-        testEmptyCommit("application/json", "")
         testEmptyCommit("application/json", "[]")
-        testEmptyCommit("application/json", "{}")
+        testEmptyCommit("application/json", "{}", status=400)
+        testEmptyCommit("application/json", "", status=400)
 
         testEmptyCommit("application/newlines", "")
         testEmptyCommit("application/newlines", "\n", status=400)
@@ -2165,6 +2165,10 @@ class TestStorageWithBatchUploadDisabled(TestStorage):
         pass
 
     def test_that_we_dont_resurrect_committed_batches(self):
+        # Without batch uploads, there's nothing for this test to test.
+        pass
+
+    def test_batch_empty_commit(self):
         # Without batch uploads, there's nothing for this test to test.
         pass
 

--- a/syncstorage/views/validators.py
+++ b/syncstorage/views/validators.py
@@ -251,7 +251,10 @@ def parse_multiple_bsos(request):
         if content_type in ("application/json", "text/plain", None):
             bso_datas = json_loads(request.body)
         elif content_type == "application/newlines":
-            bso_datas = [json_loads(ln) for ln in request.body.split("\n")]
+            bso_datas = []
+            if request.body:
+                for ln in request.body.split("\n"):
+                    bso_datas.append(json_loads(ln))
         else:
             msg = "Unsupported Media Type: %s" % (content_type,)
             request.errors.add("header", "Content-Type", msg)


### PR DESCRIPTION
This includes the tests from #71 and a code fix to make them pass.