### PR TITLE
Ensure all size limits are inclusive, and are internally consistent.

### DIFF
--- a/syncstorage/tests/functional/test_old_storage.py
+++ b/syncstorage/tests/functional/test_old_storage.py
@@ -20,7 +20,6 @@ from decimal import Decimal
 
 from syncstorage.tests.functional.support import StorageFunctionalTestCase
 from syncstorage.tests.functional.support import run_live_functional_tests
-from syncstorage.views.util import get_limit_config
 
 WEAVE_INVALID_WBO = 8
 
@@ -411,32 +410,6 @@ class TestOldStorage(StorageFunctionalTestCase):
         time.sleep(2.1)
         res = self.app.get(self.root + '/storage/col2')
         self.assertEquals(len(res.json), 0)
-
-    def test_batch(self):
-        max_count = get_limit_config(self.config, "max_post_records")
-        max_bytes = get_limit_config(self.config, "max_post_bytes")
-        self.assertEquals(max_bytes, 1024 * 1024)
-        # Test that batch uploads are correctly processed.
-        # Uploading max_count-5 small objects should succeed.
-        wbos = [{'id': str(i), 'payload': 'X'} for i in range(max_count - 5)]
-        res = self.app.post_json(self.root + '/storage/col2', wbos)
-        res = res.json
-        self.assertEquals(len(res['success']), max_count - 5)
-        self.assertEquals(len(res['failed']), 0)
-        # Uploading max_count+5 items should produce five failures.
-        wbos = [{'id': str(i), 'payload': 'X'} for i in range(max_count + 5)]
-        res = self.app.post_json(self.root + '/storage/col2', wbos)
-        res = res.json
-        self.assertEquals(len(res['success']), max_count)
-        self.assertEquals(len(res['failed']), 5)
-        # The test config has max_bytes=1M.
-        # Uploading 5 210MB items should produce one failure.
-        wbos = [{'id': str(i), 'payload': "X" * (210 * 1024)}
-                for i in range(5)]
-        res = self.app.post_json(self.root + '/storage/col2', wbos)
-        res = res.json
-        self.assertEquals(len(res['success']), 4)
-        self.assertEquals(len(res['failed']), 1)
 
     def test_weird_args(self):
         # pushing some data in col2

--- a/syncstorage/tests/tests-memcached-cacheonly.ini
+++ b/syncstorage/tests/tests-memcached-cacheonly.ini
@@ -12,6 +12,9 @@ wraps = sqlstorage
 cache_key_prefix = sync-${MOZSVC_UUID}-
 cache_only_collections = meta tabs col1 col2
 batch_upload_enabled = true
+# memcached can only store up to 1M in size
+max_post_bytes = 524288
+max_record_payload_bytes = 524288
 
 [sqlstorage]
 backend = syncstorage.storage.sql.SQLStorage

--- a/syncstorage/tests/tests-memcached-writethrough.ini
+++ b/syncstorage/tests/tests-memcached-writethrough.ini
@@ -12,6 +12,9 @@ wraps = sqlstorage
 cache_key_prefix = sync-${MOZSVC_UUID}-
 cached_collections = meta tabs col1 col2
 batch_upload_enabled = true
+# memcached can only store up to 1M in size
+max_post_bytes = 524288
+max_record_payload_bytes = 524288
 
 [sqlstorage]
 backend = syncstorage.storage.sql.SQLStorage

--- a/syncstorage/views/__init__.py
+++ b/syncstorage/views/__init__.py
@@ -10,7 +10,7 @@ from pyramid.security import Allow
 
 from cornice import Service
 
-from syncstorage.bso import VALID_ID_REGEX, MAX_PAYLOAD_SIZE
+from syncstorage.bso import VALID_ID_REGEX
 from syncstorage.util import get_timestamp
 from syncstorage.storage import (ConflictError,
                                  NotFoundError,
@@ -205,6 +205,8 @@ def get_info_configuration(request):
     # Don't return batch-related limits if the feature isn't enabled.
     if request.registry.settings.get("storage.batch_upload_enabled", False):
         LIMIT_NAMES = (
+            "max_request_bytes",
+            "max_record_payload_bytes",
             "max_post_records",
             "max_post_bytes",
             "max_total_records",
@@ -213,12 +215,11 @@ def get_info_configuration(request):
     else:
         LIMIT_NAMES = (
             "max_request_bytes",
+            "max_record_payload_bytes",
         )
     limits = {}
     for name in LIMIT_NAMES:
         limits[name] = get_limit_config(request, name)
-    # This limit is hard-coded for now.
-    limits["max_record_payload_bytes"] = MAX_PAYLOAD_SIZE
     return limits
 
 

--- a/syncstorage/views/validators.py
+++ b/syncstorage/views/validators.py
@@ -275,7 +275,8 @@ def parse_multiple_bsos(request):
     invalid_bsos = {}
 
     total_bytes = 0
-    for count, bso_data in enumerate(bso_datas):
+    count = 0
+    for bso_data in bso_datas:
         try:
             bso = BSO(bso_data)
         except ValueError:
@@ -303,12 +304,13 @@ def parse_multiple_bsos(request):
             logger.info(logmsg, userid, collection, id, msg, bso)
             continue
 
-        if count >= BATCH_MAX_COUNT:
+        count += 1
+        if count > BATCH_MAX_COUNT:
             invalid_bsos[id] = "retry bso"
             continue
 
         total_bytes += len(bso.get("payload", ""))
-        if total_bytes >= BATCH_MAX_BYTES:
+        if total_bytes > BATCH_MAX_BYTES:
             invalid_bsos[id] = "retry bytes"
             continue
 


### PR DESCRIPTION
Fixes #73, adds explicit functional tests to assert https://bugzilla.mozilla.org/show_bug.cgi?id=1401707, and includes "max_request_bytes" in the configuration report even when batches are enabled.

@mhammond r?  The changes here are mostly to test cases so if you could check whether they make sense from your perspective that'd be awesome.