### PR TITLE
Avoid triggering a 413 with large payload tests in prod.

### DIFF
--- a/syncstorage/views/util.py
+++ b/syncstorage/views/util.py
@@ -102,7 +102,7 @@ DEFAULT_LIMITS["max_total_bytes"] = 100 * DEFAULT_LIMITS["max_post_bytes"]
 # otherwise clients might attempt large uploads that get rejected before
 # they ever reach the server application code.
 #
-# We default to max_post_bytes plus some slopt for metadata and JSON
+# We default to max_post_bytes plus some slop for metadata and JSON
 # formatting.
 DEFAULT_LIMITS["max_request_bytes"] = (2 * 1024 * 1024) + 4096
 


### PR DESCRIPTION
This test was wildly overshooting the nginx limit on request body size when run against servers in stage.  I've adjusted it to be a little more conservative about how much data it sends, while still triggering the behaviour under test (which is the max BSO payload bytes, not max request bytes).

@Micheletto r?