### PR TITLE
fix(docker): Use $DOCKER_VERSION when checking checksum.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           command: |
             set -x
             curl -L -o /tmp/docker-$DOCKER_VERSION.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz
-            [[ `sha256sum /tmp/docker-17.12.1-ce.tgz  | cut -d' ' -f1` = 1270dce1bd7e1838d62ae21d2505d87f16efc1d9074645571daaefdfd0c14054 ]]
+            [[ `sha256sum /tmp/docker-$DOCKER_VERSION.tgz  | cut -d' ' -f1` = $DOCKER_CHECKSUM ]]
             tar -xz -C /tmp -f /tmp/docker-$DOCKER_VERSION.tgz
             mv /tmp/docker/* /usr/bin
       - run:


### PR DESCRIPTION
The merge of #81 failed on master with the following:

```
#!/bin/bash -eo pipefail
set -x
curl -L -o /tmp/docker-$DOCKER_VERSION.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz
[[ `sha256sum /tmp/docker-17.12.1-ce.tgz  | cut -d' ' -f1` = 1270dce1bd7e1838d62ae21d2505d87f16efc1d9074645571daaefdfd0c14054 ]]
tar -xz -C /tmp -f /tmp/docker-$DOCKER_VERSION.tgz
mv /tmp/docker/* /usr/bin

+ curl -L -o /tmp/docker-.tgz https://download.docker.com/linux/static/stable/x86_64/docker-.tgz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

100   566  100   566    0     0   3590      0 --:--:-- --:--:-- --:--:--  3605
++ sha256sum /tmp/docker-17.12.1-ce.tgz
++ cut '-d ' -f1
sha256sum: /tmp/docker-17.12.1-ce.tgz: No such file or directory
+ [[ '' = 1270dce1bd7e1838d62ae21d2505d87f16efc1d9074645571daaefdfd0c14054 ]]
Exited with code 1
```

It looks like the `$DOCKER_VERSION` variable is missing in config, and the sha checksum should not be hardcoding it.  This PR fixes the later but @autrilla I guess the former needs to be fixed in some ops circle config?