### PR TITLE
Update gunicorn dependency.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cornice==0.17
 flake8==2.4.1
 gevent==1.0.2
 greenlet==0.4.9
-gunicorn==19.3.0
+gunicorn==19.9.0
 hawkauthlib==0.1.1
 konfig==0.9
 linecache2==1.0.0


### PR DESCRIPTION
This resolves the dependency warning for older versions of gunicorn, per https://github.com/mozilla-services/server-syncstorage/network/dependencies

I don't have any reason to believe there's an actual security issue here, but updating for completeness.