### PR TITLE
Change installation of umemcache

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ gunicorn==19.9.0
 hawkauthlib==0.1.1
 konfig==0.9
 linecache2==1.0.0
-mozsvc==0.10
+mozsvc[memcache]==0.10
 nose==1.3.7
 pymysql-sa==1.0
 pyramid-hawkauth==0.1.0
@@ -31,7 +31,6 @@ testfixtures==4.3.3
 tokenlib==0.3.1
 traceback2==1.4.0
 translationstring==1.3
-umemcache==1.6.3
 unittest2==1.1.0
 venusian==1.0
 waitress==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,11 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from setuptools import setup, find_packages
-import os
-import re
 
 install_requires = ['SQLALchemy', 'unittest2', 'simplejson', 'pyramid',
-                    'mozsvc>=0.8', 'cornice', 'pyramid_hawkauth', 'PyMySQL',
-                    'pymysql_sa', 'umemcache', 'wsgiproxy',
-                    'webtest', 'requests', 'PyBrowserID', 'testfixtures']
+                    'mozsvc[memcache]>=0.8', 'cornice', 'pyramid_hawkauth',
+                    'PyMySQL', 'pymysql_sa', 'wsgiproxy', 'webtest',
+                    'requests', 'PyBrowserID', 'testfixtures']
 
 entry_points = """
 [paste.app_factory]
@@ -26,11 +24,10 @@ setup(name='SyncStorage',
       entry_points=entry_points,
       license='MPLv2.0',
       classifiers=[
-        "Programming Language :: Python",
-        "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
-        ],
+          "Programming Language :: Python",
+          "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)",
+      ],
       package_data={
           "syncstorage.tests": ["*.ini"],
       },
-      include_package_data=True,
-)
+      include_package_data=True)


### PR DESCRIPTION
`umemcache` is an optional (extra) dependency of `mozsvc`.
`umemcache` is never used directly in this module.

Since `umemcache` is used with the version of `mozsvc.storage.memcached` installed the installation style for `mozsvc` has been changed to include the extra `memcache` - which will currently install `umemcache`.
If `mozsvc` changes its dependencies for _memcache_ these changes can be picked up much easier with this style.

My main motivation behind this is that porting this library to Python 3 gets easier without `umemcache` as a direct dependency because it only supports Python 2.