### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "2.6"
   - "2.7"
 
 services:
@@ -20,7 +19,7 @@ notifications:
 
 install:
   - make build
-  - ./local/bin/pip install psycopg2
+  - ./local/bin/pip install psycopg2-binary
 
 before_script:
   - mysql -e 'create database sync_test;'

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -5,4 +5,5 @@ their contributions under the MPLv2.0:
 * Toby Elliott <telliott@mozilla.com>
 * Tarek Ziadé <tarek@mozilla.com>
 * Nicolas Steinmetz <nsteinmetz@gmail.com>
+* Niko Wenselowski <niko@nerdno.de>
 

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,29 @@
-VIRTUALENV = virtualenv
+SYSTEMPYTHON = `which python2 python | head -n 1`
+VIRTUALENV = virtualenv --python=$(SYSTEMPYTHON)
 NOSE = local/bin/nosetests -s
 TESTS = syncstorage/tests
 PYTHON = local/bin/python
 PIP = local/bin/pip
 PIP_CACHE = /tmp/pip-cache.${USER}
 BUILD_TMP = /tmp/syncstorage-build.${USER}
-PYPI = https://pypi.python.org/simple
+PYPI = https://pypi.org/simple
 
 export MOZSVC_SQLURI = sqlite:///:memory:
 
 # Hackety-hack around OSX system python bustage.
 # The need for this should go away with a future osx/xcode update.
 ARCHFLAGS = -Wno-error=unused-command-line-argument-hard-error-in-future
+CFLAGS = -Wno-error=write-strings
 
-INSTALL = ARCHFLAGS=$(ARCHFLAGS) $(PIP) install -U -i $(PYPI)
+INSTALL = ARCHFLAGS=$(ARCHFLAGS) CFLAGS=$(CFLAGS) $(PIP) install -U -i $(PYPI)
 
 .PHONY: all build test
 
 all:	build
 
 build:
-	$(VIRTUALENV) --no-site-packages --distribute ./local
-	$(INSTALL) --upgrade Distribute pip
+	$(VIRTUALENV) --no-site-packages ./local
+	$(INSTALL) --upgrade "setuptools>=0.7" pip
 	$(INSTALL) -r requirements.txt
 	$(PYTHON) ./setup.py develop
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,18 +9,17 @@ WebTest==2.0.18
 beautifulsoup4==4.4.1
 configparser==3.5.0b2
 cornice==0.17
-flake8==2.4.1
+flake8==3.5.0
+# Require at least pycodestyle 2.3 as of https://gitlab.com/pycqa/flake8/issues/381
+pycodestyle>=2.3.0
 gevent==1.0.2
 greenlet==0.4.9
 gunicorn==19.9.0
 hawkauthlib==0.1.1
 konfig==0.9
 linecache2==1.0.0
-mccabe==0.3.1
 mozsvc==0.10
 nose==1.3.7
-pep8==1.6.2
-pyflakes==1.0.0
 pymysql-sa==1.0
 pyramid-hawkauth==0.1.0
 pyramid==1.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ cornice==0.17
 flake8==2.4.1
 gevent==1.0.2
 greenlet==0.4.9
-gunicorn==19.3.0
+gunicorn==19.9.0
 hawkauthlib==0.1.1
 konfig==0.9
 linecache2==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ entry_points = """
 main = syncstorage:main
 """
 
-version = "1.6.13"
+version = "1.6.14"
 
 
 setup(name='SyncStorage',


### PR DESCRIPTION
Travis CI is a great tool for having your package tested.

This pull requests:
* Drops support for Python 2.6 (seems to be out-of-scope with deps not even running on this old Python; as per [this comment](https://github.com/mozilla-services/tokenserver/issues/102#issuecomment-281698235) production runs Python 2.7)
* Switches pyscopg2 to psycobg2-binary, which is a prepared wheel that will cut down installation time
* Will let the makefile create a virtualenv with the systems Python. This gets important if you want to run multiple Python versions.
* Updates the URL of the PyPI index to the one used by pypi.org. The old one does not receive updates.
* Fixes building umemcache (was broken once the switch to system python was made)
* Switches from Distribute to setuptools because nowadays the code bases have been merged.
* Updates the used flake8 (and adds an workaround for a problem with older versions of pycodestyle).

This should benefit everyone who wants to work on this with the help of Travis CI.