### PR TITLE
feat(backend): Pass full user object to backend storage implementations.

### DIFF
--- a/syncstorage/scripts/mcclear.py
+++ b/syncstorage/scripts/mcclear.py
@@ -48,7 +48,7 @@ def clear_memcache_data(config_file, input_file):
             uid = uid.strip()
             if uid:
                 logger.info("Clearing data for %s", uid)
-                for key in backend.iter_cache_keys(uid):
+                for key in backend.iter_cache_keys({"uid": uid}):
                     backend.cache.delete(key)
                 logger.debug("Cleared data for %s", uid)
 

--- a/syncstorage/scripts/mcread.py
+++ b/syncstorage/scripts/mcread.py
@@ -49,7 +49,7 @@ def read_memcache_data(config_file, input_file, output_file):
                 uid = uid.strip()
                 if uid:
                     logger.info("Reading data for %s", uid)
-                    for key in backend.iter_cache_keys(uid):
+                    for key in backend.iter_cache_keys({"uid": uid}):
                         value = backend.cache.get(key)
                         if value is not None:
                             output_fileobj.write("%s %s\n" % (key, value))

--- a/syncstorage/storage/__init__.py
+++ b/syncstorage/storage/__init__.py
@@ -67,11 +67,11 @@ class SyncStorage(object):
     lock_for_read() method should be used by threads that only need to read
     the data, like so::
 
-          with storage.lock_for_read(userid, collection):
-              ts = storage.get_collection_timestamp(userid, collection)
+          with storage.lock_for_read(user, collection):
+              ts = storage.get_collection_timestamp(user, collection)
               if ts <= if_modified_since:
                   raise HTTPNotModified
-              return storage.get_items(userid, collection, newer=ts)
+              return storage.get_items(user, collection, newer=ts)
 
     Any thread holding a read lock on a collection is guaranteed to see a
     fixed, consistent view of the data in that collection.  It will be
@@ -81,11 +81,11 @@ class SyncStorage(object):
     The lock_for_write() method should be used by threads that need to modify
     the data, like so::
 
-          with storage.lock_for_write(userid, collection):
-              ts = storage.get_collection_timestamp(userid, collection)
+          with storage.lock_for_write(user, collection):
+              ts = storage.get_collection_timestamp(user, collection)
               if ts > if_unmodified_since:
                   raise HTTPModified
-              storage.set_items(userid, collection, new_items)
+              storage.set_items(user, collection, new_items)
 
     There is no guarantee of mutual temporal exclusion between readers and
     writers.  For example, backends that natively support Multi-Version
@@ -98,11 +98,11 @@ class SyncStorage(object):
     # APIs for collection-level locking.
     #
 
-    def lock_for_read(self, userid, collection):
+    def lock_for_read(self, user, collection):
         """Context manager locking the storage for consistent reads.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
             collection: the name of the collection to lock.
 
         Returns:
@@ -112,11 +112,11 @@ class SyncStorage(object):
             CollectionNotFoundError: the user has no such collection.
         """
 
-    def lock_for_write(self, userid, collection):
+    def lock_for_write(self, user, collection):
         """Context manager locking the storage for consistent writes.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
             collection: the name of the collection to lock.
 
         Returns:
@@ -131,55 +131,55 @@ class SyncStorage(object):
     #
 
     @abc.abstractmethod
-    def get_storage_timestamp(self, userid):
+    def get_storage_timestamp(self, user):
         """Returns the last-modified timestamp for the entire storage.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
 
         Returns:
             The last-modified timestamp for the entire storage.
         """
 
     @abc.abstractmethod
-    def get_collection_timestamps(self, userid):
+    def get_collection_timestamps(self, user):
         """Returns the collection timestamps for a user.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
 
         Returns:
             A dict mapping collection names to their last-modified timestamp.
         """
 
     @abc.abstractmethod
-    def get_collection_counts(self, userid):
+    def get_collection_counts(self, user):
         """Returns the collection counts.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
 
         Returns:
             A dict mapping collection names to their item count.
         """
 
     @abc.abstractmethod
-    def get_collection_sizes(self, userid):
+    def get_collection_sizes(self, user):
         """Returns the total size for each collection.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
 
         Returns:
             A dict mapping collection names to their total size.
         """
 
     @abc.abstractmethod
-    def get_total_size(self, userid, recalculate=False):
+    def get_total_size(self, user, recalculate=False):
         """Returns the total size a user's stored data.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
             recalculate: whether to recalculate any cached size data.
 
         Returns:
@@ -187,11 +187,11 @@ class SyncStorage(object):
         """
 
     @abc.abstractmethod
-    def delete_storage(self, userid):
+    def delete_storage(self, user):
         """Removes all data for the user.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
 
         Returns:
             None
@@ -205,11 +205,11 @@ class SyncStorage(object):
     #
 
     @abc.abstractmethod
-    def get_collection_timestamp(self, userid, collection):
+    def get_collection_timestamp(self, user, collection):
         """Returns the last-modified timestamp for the named collection.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
             collection: name of the collection.
 
         Returns:
@@ -220,12 +220,12 @@ class SyncStorage(object):
         """
 
     @abc.abstractmethod
-    def get_items(self, userid, collection, items=None, newer=None,
+    def get_items(self, user, collection, items=None, newer=None,
                   older=None, limit=None, offset=None, sort=None):
         """Returns items from a collection
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
             collection: name of the collection.
             items: list of strings identifying items to return.
             newer: float; only return items newer than this timestamp.
@@ -245,12 +245,12 @@ class SyncStorage(object):
         """
 
     @abc.abstractmethod
-    def get_item_ids(self, userid, collection, items=None, newer=None,
+    def get_item_ids(self, user, collection, items=None, newer=None,
                      older=None, limit=None, offset=None, sort=None):
         """Returns item ids from a collection
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
             collection: name of the collection.
             items: list of strings identifying items to return.
             newer: float; only return items newer than this timestamp.
@@ -270,11 +270,11 @@ class SyncStorage(object):
         """
 
     @abc.abstractmethod
-    def set_items(self, userid, collection, items):
+    def set_items(self, user, collection, items):
         """Creates or updates multiple items in a collection.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
             collection: name of the collection.
             items: a list of dicts giving data for each item.
 
@@ -286,11 +286,11 @@ class SyncStorage(object):
         """
 
     @abc.abstractmethod
-    def delete_collection(self, userid, collection):
+    def delete_collection(self, user, collection):
         """Deletes an entire collection.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
             collection: name of the collection.
 
         Returns:
@@ -302,11 +302,11 @@ class SyncStorage(object):
         """
 
     @abc.abstractmethod
-    def delete_items(self, userid, collection, items):
+    def delete_items(self, user, collection, items):
         """Deletes multiple items from a collection.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
             collection: name of the collection.
             items: list of strings identifying the items to be removed.
 
@@ -319,11 +319,11 @@ class SyncStorage(object):
         """
 
     @abc.abstractmethod
-    def create_batch(self, userid, collection):
+    def create_batch(self, user, collection):
         """Creates a batch for multi-POST batch uploads.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
             collection: name of the collection.
 
         Returns:
@@ -331,11 +331,11 @@ class SyncStorage(object):
         """
 
     @abc.abstractmethod
-    def valid_batch(self, userid, collection, batchid):
+    def valid_batch(self, user, collection, batchid):
         """Verifies that a batch ID exists for a given user's collection.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
             collection: name of the collection.
             batchid: big integer batch identifier for this batch
 
@@ -345,12 +345,12 @@ class SyncStorage(object):
         """
 
     @abc.abstractmethod
-    def append_items_to_batch(self, userid, collection, batchid, items):
+    def append_items_to_batch(self, user, collection, batchid, items):
         """Creates or updates multiple items from a multi-POST batch to a
         batch.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
             collection: name of the collection.
             batchid: big integer batch identifier for this batch
             items: a list of dicts giving data for each item.
@@ -363,11 +363,11 @@ class SyncStorage(object):
         """
 
     @abc.abstractmethod
-    def apply_batch(self, userid, collection, batchid):
+    def apply_batch(self, user, collection, batchid):
         """Applies the pending batch.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
             collection: name of the collection.
             batchid: big integer batch identifier for this batch
 
@@ -380,11 +380,11 @@ class SyncStorage(object):
         """
 
     @abc.abstractmethod
-    def close_batch(self, userid, collection, batchid):
+    def close_batch(self, user, collection, batchid):
         """Close a specific batch.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
             collection: name of the collection.
             batchid: big integer batch identifier for this batch
         """
@@ -394,11 +394,11 @@ class SyncStorage(object):
     #
 
     @abc.abstractmethod
-    def get_item_timestamp(self, userid, collection, item):
+    def get_item_timestamp(self, user, collection, item):
         """Returns the last-modified timestamp for the named item.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
             collection: name of the collection.
             item: string identifying the item.
 
@@ -411,11 +411,11 @@ class SyncStorage(object):
         """
 
     @abc.abstractmethod
-    def get_item(self, userid, collection, item):
+    def get_item(self, user, collection, item):
         """Returns one item from a collection.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
             collection: name of the collection.
             item: string identifying the item.
 
@@ -428,11 +428,11 @@ class SyncStorage(object):
         """
 
     @abc.abstractmethod
-    def set_item(self, userid, collection, item, data):
+    def set_item(self, user, collection, item, data):
         """Creates or updates a single item in a collection.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
             collection: name of the collection.
             item: string identifying the item
             data: dict containing the new item data.
@@ -447,11 +447,11 @@ class SyncStorage(object):
         """
 
     @abc.abstractmethod
-    def delete_item(self, userid, collection, item):
+    def delete_item(self, user, collection, item):
         """Deletes a single item from a collection.
 
         Args:
-            userid: integer identifying the user in the storage.
+            user: user object identifying the user in the storage.
             collection: name of the collection.
             item: string identifying the item
 

--- a/syncstorage/tests/test_storage.py
+++ b/syncstorage/tests/test_storage.py
@@ -12,7 +12,8 @@ from syncstorage.storage import (SyncStorage,
                                  ItemNotFoundError,
                                  CollectionNotFoundError)
 
-_UID = 1
+_USER1 = {'uid': 1}
+_USER2 = {'uid': 2}
 _PLD = '*' * 500
 
 
@@ -26,103 +27,103 @@ class StorageTestsMixin(object):
 
     def test_items(self):
         self.assertRaises(CollectionNotFoundError,
-                          self.storage.get_items, _UID, 'col')
-        self.storage.set_items(_UID, 'col', [])
+                          self.storage.get_items, _USER1, 'col')
+        self.storage.set_items(_USER1, 'col', [])
         self.assertRaises(ItemNotFoundError,
-                          self.storage.get_item_timestamp, _UID, 'col', '1')
+                          self.storage.get_item_timestamp, _USER1, 'col', '1')
 
-        self.storage.set_item(_UID, 'col', '1', {'payload': _PLD})
-        res = self.storage.get_item(_UID, 'col', '1')
+        self.storage.set_item(_USER1, 'col', '1', {'payload': _PLD})
+        res = self.storage.get_item(_USER1, 'col', '1')
         self.assertEquals(res['payload'], _PLD)
 
-        self.storage.set_item(_UID, 'col', '2', {'payload': _PLD})
+        self.storage.set_item(_USER1, 'col', '2', {'payload': _PLD})
 
-        items = self.storage.get_items(_UID, 'col')["items"]
+        items = self.storage.get_items(_USER1, 'col')["items"]
         self.assertEquals(len(items), 2)
 
-        self.storage.delete_item(_UID, 'col', '1')
-        items = self.storage.get_items(_UID, 'col')["items"]
+        self.storage.delete_item(_USER1, 'col', '1')
+        items = self.storage.get_items(_USER1, 'col')["items"]
         self.assertEquals(len(items), 1)
 
-        self.storage.delete_collection(_UID, 'col')
+        self.storage.delete_collection(_USER1, 'col')
         self.assertRaises(CollectionNotFoundError,
-                          self.storage.get_items, _UID, 'col')
+                          self.storage.get_items, _USER1, 'col')
 
-        self.storage.set_items(_UID, 'col', [{'id': 'o', 'payload': _PLD}])
-        res = self.storage.get_item(_UID, 'col', 'o')
+        self.storage.set_items(_USER1, 'col', [{'id': 'o', 'payload': _PLD}])
+        res = self.storage.get_item(_USER1, 'col', 'o')
         self.assertEquals(res['payload'], _PLD)
 
     def test_batches(self):
         self.assertRaises(CollectionNotFoundError,
-                          self.storage.get_items, _UID, 'col')
-        self.storage.set_item(_UID, 'col', 'o', {'payload': 'trance'})
+                          self.storage.get_items, _USER1, 'col')
+        self.storage.set_item(_USER1, 'col', 'o', {'payload': 'trance'})
 
-        batch = self.storage.create_batch(_UID, 'col')
-        self.storage.append_items_to_batch(_UID, 'col', batch,
+        batch = self.storage.create_batch(_USER1, 'col')
+        self.storage.append_items_to_batch(_USER1, 'col', batch,
                                            [{'id': 'o',
                                              'payload': 'tweaked'}])
-        self.storage.apply_batch(_UID, 'col', batch)
-        res = self.storage.get_item(_UID, 'col', 'o')
+        self.storage.apply_batch(_USER1, 'col', batch)
+        res = self.storage.get_item(_USER1, 'col', 'o')
         self.assertEquals(res['payload'], 'tweaked')
 
     def test_get_collection_timestamps(self):
-        self.storage.set_item(_UID, 'col1', '1', {'payload': _PLD})
-        self.storage.set_item(_UID, 'col2', '1', {'payload': _PLD})
+        self.storage.set_item(_USER1, 'col1', '1', {'payload': _PLD})
+        self.storage.set_item(_USER1, 'col2', '1', {'payload': _PLD})
 
-        timestamps = self.storage.get_collection_timestamps(_UID)
+        timestamps = self.storage.get_collection_timestamps(_USER1)
         names = timestamps.keys()
         self.assertTrue('col1' in names)
         self.assertTrue('col2' in names)
-        col2ts = self.storage.get_collection_timestamp(_UID, 'col2')
+        col2ts = self.storage.get_collection_timestamp(_USER1, 'col2')
         self.assertAlmostEquals(col2ts, timestamps['col2'])
 
         # check that when we have several users, the method
         # still returns the same timestamp for the first user
         # which differs from the second user
-        self.storage.set_item(_UID, 'col1', '1', {'payload': _PLD})
-        self.storage.set_item(_UID, 'col2', '1', {'payload': _PLD})
+        self.storage.set_item(_USER1, 'col1', '1', {'payload': _PLD})
+        self.storage.set_item(_USER1, 'col2', '1', {'payload': _PLD})
 
-        user1_timestamps = self.storage.get_collection_timestamps(_UID)
+        user1_timestamps = self.storage.get_collection_timestamps(_USER1)
         user1_timestamps = user1_timestamps.items()
         user1_timestamps.sort()
 
-        user2_timestamps = self.storage.get_collection_timestamps(2)
+        user2_timestamps = self.storage.get_collection_timestamps(_USER2)
         user2_timestamps = user2_timestamps.items()
         user2_timestamps.sort()
 
         self.assertNotEqual(user1_timestamps, user2_timestamps)
 
     def test_storage_size(self):
-        before = self.storage.get_total_size(_UID)
-        self.storage.set_item(_UID, 'col1', '1', {'payload': _PLD})
-        self.storage.set_item(_UID, 'col1', '2', {'payload': _PLD})
+        before = self.storage.get_total_size(_USER1)
+        self.storage.set_item(_USER1, 'col1', '1', {'payload': _PLD})
+        self.storage.set_item(_USER1, 'col1', '2', {'payload': _PLD})
         wanted = len(_PLD) * 2
-        self.assertEquals(self.storage.get_total_size(_UID) - before, wanted)
+        self.assertEquals(self.storage.get_total_size(_USER1) - before, wanted)
 
     def test_ttl(self):
-        self.storage.set_item(_UID, 'col1', '1', {'payload': _PLD})
-        self.storage.set_item(_UID, 'col1', '2', {'payload': _PLD, 'ttl': 0})
+        self.storage.set_item(_USER1, 'col1', '1', {'payload': _PLD})
+        self.storage.set_item(_USER1, 'col1', '2', {'payload': _PLD, 'ttl': 0})
         time.sleep(1.1)
-        items = self.storage.get_items(_UID, 'col1')["items"]
+        items = self.storage.get_items(_USER1, 'col1')["items"]
         self.assertEquals(len(items), 1)
-        items = self.storage.get_items(_UID, 'col1', ttl=-1)["items"]
+        items = self.storage.get_items(_USER1, 'col1', ttl=-1)["items"]
         self.assertEquals(len(items), 2)
 
     def test_dashed_ids(self):
         id1 = 'ec1b7457-003a-45a9-bf1c-c34e37225ad7'
         id2 = '339f52e1-deed-497c-837a-1ab25a655e37'
-        self.storage.set_item(_UID, 'col1', id1, {'payload': _PLD})
-        self.storage.set_item(_UID, 'col1', id2, {'payload': _PLD * 89})
-        items = self.storage.get_items(_UID, 'col1')["items"]
+        self.storage.set_item(_USER1, 'col1', id1, {'payload': _PLD})
+        self.storage.set_item(_USER1, 'col1', id2, {'payload': _PLD * 89})
+        items = self.storage.get_items(_USER1, 'col1')["items"]
         self.assertEquals(len(items), 2)
-        self.storage.delete_items(_UID, 'col1', [id1, id2])
-        items = self.storage.get_items(_UID, 'col1')["items"]
+        self.storage.delete_items(_USER1, 'col1', [id1, id2])
+        items = self.storage.get_items(_USER1, 'col1')["items"]
         self.assertEquals(len(items), 0)
 
     def test_collection_locking_enforces_consistency(self):
         # Create the collection and get initial timestamp.
         bso = {"id": "TEST", "payload": _PLD}
-        ts0 = self.storage.set_items(_UID, "col1", [bso])
+        ts0 = self.storage.set_items(_USER1, "col1", [bso])
 
         # Some events to coordinate action between the threads.
         read_locked = threading.Event()
@@ -145,19 +146,19 @@ class StorageTestsMixin(object):
         # match the initial timestamp despite concurrent write thread.
         @catch_failures
         def reader_thread():
-            with self.storage.lock_for_read(_UID, "col1"):
+            with self.storage.lock_for_read(_USER1, "col1"):
                 read_locked.set()
-                ts1 = self.storage.get_collection_timestamp(_UID, "col1")
+                ts1 = self.storage.get_collection_timestamp(_USER1, "col1")
                 self.assertEquals(ts0, ts1)
                 # Give the writer a chance to update the value.
                 # It may be blocking on us though, so don't wait forever.
                 write_complete.wait(timeout=1)
-                ts2 = self.storage.get_collection_timestamp(_UID, "col1")
+                ts2 = self.storage.get_collection_timestamp(_USER1, "col1")
                 self.assertEquals(ts1, ts2)
             # After releasing our read lock, the writer should complete.
             # Make sure its changes are visible to this thread.
             write_complete.wait()
-            ts3 = self.storage.get_collection_timestamp(_UID, "col1")
+            ts3 = self.storage.get_collection_timestamp(_USER1, "col1")
             self.assertTrue(ts2 < ts3)
 
         # A writer thread.  It waits until the collection is locked for
@@ -170,17 +171,17 @@ class StorageTestsMixin(object):
             storage = self.storage
             while True:
                 try:
-                    with self.storage.lock_for_write(_UID, "col1"):
-                        ts1 = storage.get_collection_timestamp(_UID, "col1")
+                    with self.storage.lock_for_write(_USER1, "col1"):
+                        ts1 = storage.get_collection_timestamp(_USER1, "col1")
                         self.assertEquals(ts0, ts1)
-                        ts2 = storage.set_items(_UID, "col1", [bso])
+                        ts2 = storage.set_items(_USER1, "col1", [bso])
                         self.assertTrue(ts1 < ts2)
                         break
                 except ConflictError:
                     continue
             write_complete.set()
             # Check that our changes are visible outside of the lock.
-            ts3 = storage.get_collection_timestamp(_UID, "col1")
+            ts3 = storage.get_collection_timestamp(_USER1, "col1")
             self.assertEquals(ts2, ts3)
 
         reader = threading.Thread(target=reader_thread)

--- a/syncstorage/views/decorators.py
+++ b/syncstorage/views/decorators.py
@@ -94,7 +94,7 @@ def check_storage_quota(viewfunc, request):
         return viewfunc(request)
 
     storage = request.validated["storage"]
-    userid = request.validated["userid"]
+    user = request.user
     quota_size = request.registry.settings.get("storage.quota_size")
 
     # Don't do anything if quotas are not enabled.
@@ -103,10 +103,10 @@ def check_storage_quota(viewfunc, request):
 
     # Get the total size used from the underlying store, which may be cached.
     # If we're close to going over quota, ask it to recalculate fresher info.
-    used = storage.get_total_size(userid)
+    used = storage.get_total_size(user)
     left = quota_size - used
     if left < ONE_MB:
-        used = storage.get_total_size(userid, recalculate=True)
+        used = storage.get_total_size(user, recalculate=True)
         left = quota_size - used
 
     # Look for new items that will be written by this request,
@@ -175,7 +175,7 @@ def with_collection_lock(viewfunc, request):
     If the request does not target a specific collection, no lock is taken.
     """
     storage = request.validated["storage"]
-    userid = request.validated["userid"]
+    user = request.user
     collection = request.validated.get("collection")
 
     # If we're not operating on a collection, don't take a lock.
@@ -189,5 +189,5 @@ def with_collection_lock(viewfunc, request):
         lock_collection = storage.lock_for_read
     else:
         lock_collection = storage.lock_for_write
-    with lock_collection(userid, collection):
+    with lock_collection(user, collection):
         return viewfunc(request)

--- a/syncstorage/views/util.py
+++ b/syncstorage/views/util.py
@@ -67,24 +67,24 @@ def get_resource_timestamp(request):
     If the target resource does not exist, it returns zero.
     """
     storage = request.validated["storage"]
-    userid = request.validated["userid"]
+    user = request.user
     collection = request.validated.get("collection")
     item = request.validated.get("item")
 
     # No collection name => return overall storage timestamp.
     if collection is None:
-        return storage.get_storage_timestamp(userid)
+        return storage.get_storage_timestamp(user)
 
     # No item id => return timestamp of whole collection.
     if item is None:
         try:
-            return storage.get_collection_timestamp(userid, collection)
+            return storage.get_collection_timestamp(user, collection)
         except NotFoundError:
             return 0
 
     # Otherwise, return timestamp of specific item.
     try:
-        return storage.get_item_timestamp(userid, collection, item)
+        return storage.get_item_timestamp(user, collection, item)
     except NotFoundError:
         return 0
 


### PR DESCRIPTION
This passes the full `request.user` object through to backend storage implementations, rather than just the numeric userid.  With this change in place, a future backend could choose to grab the `fxa_uid` and `fxa_kid` keys out of `request.user` and use those for indexing into storage, rather than using the numeric id allocated by tokenserver.

It's a big change, but it's largely mechanical, and AFAIK it should be entirely contained to this repo.  The only weird bit was the handling of expired tokens, which took me a few attempts to get figured out, but I think has successfully maintained its simplicity and safety.

@bbangert thoughts? (and if it seems like a reasonable approach, r?)

Connects to https://github.com/mozilla-services/tokenserver/issues/121