### PR TITLE
docs: fix links to point to moved content

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This is the storage engine for version 1.5 of the Firefox Sync Server.
 It implements the API defined at:
 
-   * https://docs.services.mozilla.com/storage/apis-1.5.html
+   * https://mozilla-services.readthedocs.io/en/latest/storage/apis-1.5.html
 
 This code is only one part of the full Sync Server stack and is unlikely
 to be useful in isolation.
@@ -13,9 +13,9 @@ to be useful in isolation.
 If you want to run a self-hosted version of the Sync Server,
 you should start from here:
 
-   * https://docs.services.mozilla.com/howtos/run-sync-1.5.html
+   * https://mozilla-services.readthedocs.io/en/latest/howtos/run-sync-1.5.html
 
 More general information can be found at the following links:
 
-   * https://docs.services.mozilla.com/storage/
+   * https://mozilla-services.readthedocs.io/en/latest/storage
    * https://wiki.mozilla.org/Services/Sync


### PR DESCRIPTION
Closes [123](https://github.com/mozilla-services/server-syncstorage/issues/123)