### PR TITLE
feat: Add table to cross check user migration status

### DIFF
--- a/syncstorage/storage/__init__.py
+++ b/syncstorage/storage/__init__.py
@@ -464,6 +464,21 @@ class SyncStorage(object):
             ItemNotFoundError: the collection contains no such item.
         """
 
+    @abc.abstractmethod
+    def is_migrating(self, user):
+        """Determine if a given user record is migrating to a new storage backend
+
+        Args:
+            user: user object identifying the user in the storage.
+
+        Returns:
+            Boolean indicating if this user is in migration.
+
+        Raises:
+            None
+
+        """
+
     #
     # Administrative/maintenance methods.
     #

--- a/syncstorage/storage/memcached.py
+++ b/syncstorage/storage/memcached.py
@@ -422,6 +422,10 @@ class MemcachedStorage(SyncStorage):
             update(ts, ts)
             return ts
 
+    def is_migrating(self, user):
+        """Is the user in migration?"""
+        return self.storage.is_migrating(user)
+
     #
     # Administrative/maintenance methods.
     #

--- a/syncstorage/storage/sql/__init__.py
+++ b/syncstorage/storage/sql/__init__.py
@@ -132,6 +132,7 @@ class SQLStorage(SyncStorage):
     """
 
     def __init__(self, sqluri, standard_collections=False, **dbkwds):
+        self.allow_migration = dbkwds.get("allow_migration", False)
         self.sqluri = sqluri
         self.dbconnector = DBConnector(sqluri, **dbkwds)
         self._optimize_table_before_purge = \
@@ -408,12 +409,13 @@ class SQLStorage(SyncStorage):
         guessing if a migration has not yet started.
 
         """
-        userid = user.get("fxa_uid")
-        if userid is not None:
-            res = session.query_fetchone("MIGRATION_CHECK", {
-                "fxa_uid": userid
-            })
-            return res is not None
+        if self.allow_migration:
+            userid = user.get("fxa_uid")
+            if userid is not None:
+                res = session.query_fetchone("MIGRATION_CHECK", {
+                    "fxa_uid": userid
+                })
+                return res is not None
         return False
 
     def _row_to_bso(self, row, timestamp):

--- a/syncstorage/storage/sql/__init__.py
+++ b/syncstorage/storage/sql/__init__.py
@@ -397,6 +397,25 @@ class SQLStorage(SyncStorage):
             "next_offset": next_offset,
         }
 
+    @with_session
+    def is_migrating(self, session, user):
+        """Returns True if the user is migrating.
+
+        This should probably NOT be a cached call, since migration
+        may start at any time during a client sync.
+
+        any error will percolate up as a 500, which will be safer than
+        guessing if a migration has not yet started.
+
+        """
+        userid = user.get("fxa_uid")
+        if userid is not None:
+            res = session.query_fetchone("MIGRATION_CHECK", {
+                "fxa_uid": userid
+            })
+            return res is not None
+        return False
+
     def _row_to_bso(self, row, timestamp):
         """Convert a database table row into a BSO object."""
         item = dict(row)

--- a/syncstorage/storage/sql/dbconnect.py
+++ b/syncstorage/storage/sql/dbconnect.py
@@ -379,7 +379,10 @@ class DBConnector(object):
             collections.create(self.engine, checkfirst=True)
             user_collections.create(self.engine, checkfirst=True)
             batch_uploads.create(self.engine, checkfirst=True)
-            migration.create(self.engine, checkfirst=True)
+            # only create migration if "[storage]:allow_migration" flag
+            # is set
+            if kwds.get("allow_migration", False):
+                migration.create(self.engine, checkfirst=True)
             if not self.shard:
                 bso.create(self.engine, checkfirst=True)
                 bui.create(self.engine, checkfirst=True)

--- a/syncstorage/storage/sql/dbconnect.py
+++ b/syncstorage/storage/sql/dbconnect.py
@@ -102,6 +102,22 @@ user_collections = Table(
 )
 
 
+# Table listing migration state for users
+#
+# This table contains the users in progress for migration. This table may
+# be updated by the external user migration script
+# A fxa_uid appearing in this table should cause the server to return a 5xx
+# response. It's important that the server NEVER return a 2xx response.
+
+migration = Table(
+    "migration",
+    metadata,
+    Column("fxa_uid", String(255), primary_key=True, nullable=False),
+    Column("started_at", BigInteger, nullable=False),
+    Column("state", String(32))  # unknown/NULL, in_progress, complete
+)
+
+
 # Column definitions for BSO storage table/tables.
 #
 # This list class defines the columns used for storage of BSO records.
@@ -363,6 +379,7 @@ class DBConnector(object):
             collections.create(self.engine, checkfirst=True)
             user_collections.create(self.engine, checkfirst=True)
             batch_uploads.create(self.engine, checkfirst=True)
+            migration.create(self.engine, checkfirst=True)
             if not self.shard:
                 bso.create(self.engine, checkfirst=True)
                 bui.create(self.engine, checkfirst=True)

--- a/syncstorage/storage/sql/queries_generic.py
+++ b/syncstorage/storage/sql/queries_generic.py
@@ -191,6 +191,12 @@ CLOSE_BATCH_ITEMS = """
     WHERE batch = :batch AND userid = :userid
 """
 
+MIGRATION_CHECK = """
+    SELECT started_at FROM migration
+    WHERE fxa_uid = :fxa_uid
+    LIMIT 1
+"""
+
 
 def FIND_ITEMS(bso, params):
     """Item search query.

--- a/syncstorage/tests/functional/support.py
+++ b/syncstorage/tests/functional/support.py
@@ -45,7 +45,7 @@ class StorageFunctionalTestCase(FunctionalTestCase, StorageTestCase):
         orig_do_request = self.app.do_request
         self.app.do_request = new_do_request
 
-    def _authenticate(self):
+    def _authenticate(self, fxa_uid=None):
         # For basic testing, use a random uid and sign our own tokens.
         # Subclasses might like to override this and use a live tokenserver.
         self.user_id = random.randint(1, 100000)
@@ -55,7 +55,7 @@ class StorageFunctionalTestCase(FunctionalTestCase, StorageTestCase):
             req, self.user_id, extra={
                 # Include a hashed_fxa_uid to trigger uid/kid extraction
                 "hashed_fxa_uid": str(uuid.uuid4()),
-                "fxa_uid": str(uuid.uuid4()),
+                "fxa_uid": fxa_uid or str(uuid.uuid4()),
                 "fxa_kid": str(uuid.uuid4()),
             }
         )

--- a/syncstorage/tests/test_sql.py
+++ b/syncstorage/tests/test_sql.py
@@ -31,7 +31,7 @@ class TestSQLStorage(StorageTestCase, StorageTestsMixin):
 
     def setUp(self):
         super(TestSQLStorage, self).setUp()
-        settings = self.config.registry.settings
+        settings = self.config.registry.setting
         self.storage = load_storage_from_settings("storage", settings)
 
     def test_no_create(self):
@@ -216,6 +216,10 @@ class TestSQLStorage(StorageTestCase, StorageTestsMixin):
             )
 
     def test_migrating(self):
+        settings = self.config.registry.setting
+        settings['allow_migration'] = True
+        self.storage = load_storage_from_settings("storage", settings)
+
         migrating_id = str(uuid.uuid4())
         self.assertFalse(
             self.storage.is_migrating(
@@ -225,6 +229,15 @@ class TestSQLStorage(StorageTestCase, StorageTestsMixin):
         )
         self._set_migrating_state(migrating_id, 'in_progress')
         self.assertTrue(
+            self.storage.is_migrating(
+                {"fxa_uid": migrating_id,
+                 "uid": 1}
+            )
+        )
+
+        self.storage.allow_migration = False
+        self._set_migrating_state(migrating_id, 'in_progress')
+        self.assertFalse(
             self.storage.is_migrating(
                 {"fxa_uid": migrating_id,
                  "uid": 1}

--- a/syncstorage/tests/test_sql.py
+++ b/syncstorage/tests/test_sql.py
@@ -31,7 +31,7 @@ class TestSQLStorage(StorageTestCase, StorageTestsMixin):
 
     def setUp(self):
         super(TestSQLStorage, self).setUp()
-        settings = self.config.registry.setting
+        settings = self.config.registry.settings
         self.storage = load_storage_from_settings("storage", settings)
 
     def test_no_create(self):
@@ -216,8 +216,8 @@ class TestSQLStorage(StorageTestCase, StorageTestsMixin):
             )
 
     def test_migrating(self):
-        settings = self.config.registry.setting
-        settings['allow_migration'] = True
+        settings = self.config.registry.settings
+        settings['storage.allow_migration'] = True
         self.storage = load_storage_from_settings("storage", settings)
 
         migrating_id = str(uuid.uuid4())
@@ -236,7 +236,6 @@ class TestSQLStorage(StorageTestCase, StorageTestsMixin):
         )
 
         self.storage.allow_migration = False
-        self._set_migrating_state(migrating_id, 'in_progress')
         self.assertFalse(
             self.storage.is_migrating(
                 {"fxa_uid": migrating_id,

--- a/syncstorage/tests/test_wsgiapp.py
+++ b/syncstorage/tests/test_wsgiapp.py
@@ -36,14 +36,17 @@ class TestWSGIApp(StorageTestCase):
         sqluri = get_storage(req).sqluri
         self.assertTrue(sqluri.startswith("sqlite:////tmp/another-test-host-"))
 
-    def _make_test_app(self):
+    def _make_test_app(self, user=None):
         app = TestApp(self.config.make_wsgi_app())
 
         # Monkey-patch the app to make legitimate hawk-signed requests.
-        user_id = 42
+        if user is None:
+            user = {}
+        user_id = user.get('uid', 42)
         auth_policy = self.config.registry.getUtility(IAuthenticationPolicy)
         req = Request.blank("http://localhost/")
-        auth_token, auth_secret = auth_policy.encode_hawk_id(req, user_id)
+        auth_token, auth_secret = auth_policy.encode_hawk_id(req, user_id,
+                                                             user)
 
         def new_do_request(req, *args, **kwds):
             hawkauthlib.sign_request(req, auth_token, auth_secret)
@@ -57,6 +60,7 @@ class TestWSGIApp(StorageTestCase):
     def _make_signed_req(self, userid, user):
         auth_policy = self.config.registry.getUtility(IAuthenticationPolicy)
         req = Request.blank("http://localhost/")
+        req.registry = self.config.registry
         auth_token, auth_secret = auth_policy.encode_hawk_id(req, userid, user)
         hawkauthlib.sign_request(req, auth_token, auth_secret)
         req.metrics = {}
@@ -109,20 +113,7 @@ class TestWSGIApp(StorageTestCase):
             assert False, "log was not generated"
 
     def test_metrics_capture_for_batch_uploads(self):
-        app = TestApp(self.config.make_wsgi_app())
-
-        # Monkey-patch the app to make legitimate hawk-signed requests.
-        user_id = 42
-        auth_policy = self.config.registry.getUtility(IAuthenticationPolicy)
-        req = Request.blank("http://localhost/")
-        auth_token, auth_secret = auth_policy.encode_hawk_id(req, user_id)
-
-        def new_do_request(req, *args, **kwds):
-            hawkauthlib.sign_request(req, auth_token, auth_secret)
-            return orig_do_request(req, *args, **kwds)
-
-        orig_do_request = app.do_request
-        app.do_request = new_do_request
+        app = self._make_test_app()
 
         collection = "/1.5/42/storage/xxx_col1"
 
@@ -147,6 +138,32 @@ class TestWSGIApp(StorageTestCase):
                 break
         else:
             assert False, "timer metrics were not emitted"
+
+    def test_503s_for_migrating_users(self):
+        user = {
+            "uid": 42,
+            "fxa_uid": "foobar",
+            "fxa_kid": "001122",
+            "hashed_fxa_uid": "aabbcc",
+        }
+        app = self._make_test_app(user)
+        req = self._make_signed_req(user["uid"], user)
+
+        # There's no public API for marking a user as migrated.
+        storage = get_storage(req)
+        with storage.dbconnector.connect() as connection:
+            connection.execute("""
+                INSERT INTO migration (fxa_uid, started_at, state)
+                VALUES (:fxa_uid, :started_at, :state)
+                /* queryName=migrate */
+            """, params={
+                "fxa_uid": "foobar",
+                "started_at": 12345,
+                "state": "in_progress",
+            })
+
+        res = app.get("/1.5/42/info/collections", status=503)
+        self.assertTrue("Retry-After" in res.headers)
 
     def test_receiving_old_style_fxa_uid_in_auth_token(self):
         auth_policy = self.config.registry.getUtility(IAuthenticationPolicy)

--- a/syncstorage/tests/tests-hostname.ini
+++ b/syncstorage/tests/tests-hostname.ini
@@ -4,6 +4,7 @@ sqluri = sqlite:///:memory:
 quota_size = 5242880
 create_tables = true
 batch_upload_enabled = true
+allow_migration=true
 
 [host:some-test-host]
 storage.sqluri = sqlite:////tmp/some-test-host-${MOZSVC_UUID}.db

--- a/syncstorage/views/__init__.py
+++ b/syncstorage/views/__init__.py
@@ -27,7 +27,8 @@ from syncstorage.views.decorators import (convert_storage_errors,
                                           sleep_and_retry_on_conflict,
                                           with_collection_lock,
                                           check_precondition_headers,
-                                          check_storage_quota)
+                                          check_storage_quota,
+                                          check_migration)
 from syncstorage.views.util import get_resource_timestamp, get_limit_config
 
 
@@ -179,6 +180,7 @@ item = SyncStorageService(name="item",
 
 @info_timestamps.get(accept="application/json", renderer="sync-json",
                      acl=expired_token_acl)
+@check_migration
 @default_decorators
 def get_info_timestamps(request):
     storage = request.validated["storage"]
@@ -192,6 +194,7 @@ def get_info_timestamps(request):
 
 
 @info_counts.get(accept="application/json", renderer="sync-json")
+@check_migration
 @default_decorators
 def get_info_counts(request):
     storage = request.validated["storage"]
@@ -201,6 +204,7 @@ def get_info_counts(request):
 
 
 @info_quota.get(accept="application/json", renderer="sync-json")
+@check_migration
 @default_decorators
 def get_info_quota(request):
     storage = request.validated["storage"]
@@ -212,6 +216,7 @@ def get_info_quota(request):
 
 
 @info_usage.get(accept="application/json", renderer="sync-json")
+@check_migration
 @default_decorators
 def get_info_usage(request):
     storage = request.validated["storage"]
@@ -223,6 +228,7 @@ def get_info_usage(request):
 
 
 @info_configuration.get(accept="application/json", renderer="sync-json")
+@check_migration
 @default_decorators
 def get_info_configuration(request):
     # Don't return batch-related limits if the feature isn't enabled.
@@ -247,6 +253,7 @@ def get_info_configuration(request):
 
 
 @storage.delete(renderer="sync-json")
+@check_migration
 @default_decorators
 def delete_storage(request):
     storage = request.validated["storage"]
@@ -255,6 +262,7 @@ def delete_storage(request):
 
 
 @service_root.delete(renderer="sync-json")
+@check_migration
 @default_decorators
 def delete_all(request):
     storage = request.validated["storage"]
@@ -264,6 +272,7 @@ def delete_all(request):
 
 @collection.get(accept="application/json", renderer="sync-json")
 @collection.get(accept="application/newlines", renderer="sync-newlines")
+@check_migration
 @convert_storage_errors
 def get_collection_with_internal_pagination(request):
     """Get the contents of a collection, in a respectful manner.
@@ -324,6 +333,7 @@ def get_collection_with_internal_pagination(request):
 @sleep_and_retry_on_conflict
 @with_collection_lock
 @check_precondition_headers
+@check_migration
 @check_storage_quota
 def get_collection(request):
     storage = request.validated["storage"]
@@ -355,6 +365,7 @@ def get_collection(request):
 
 @collection.post(accept="application/json", renderer="sync-json",
                  validators=POST_VALIDATORS)
+@check_migration
 @default_decorators
 def post_collection(request):
     storage = request.validated["storage"]
@@ -383,6 +394,7 @@ def post_collection(request):
     return res
 
 
+@check_migration
 def post_collection_batch(request):
     storage = request.validated["storage"]
     user = request.user
@@ -461,6 +473,7 @@ def post_collection_batch(request):
 
 
 @collection.delete(renderer="sync-json")
+@check_migration
 @default_decorators
 def delete_collection(request):
     storage = request.validated["storage"]
@@ -481,6 +494,7 @@ def delete_collection(request):
 
 
 @item.get(accept="application/json", renderer="sync-json")
+@check_migration
 @default_decorators
 def get_item(request):
     storage = request.validated["storage"]
@@ -493,6 +507,7 @@ def get_item(request):
 
 
 @item.put(renderer="sync-json", validators=PUT_VALIDATORS)
+@check_migration
 @default_decorators
 def put_item(request):
     storage = request.validated["storage"]
@@ -508,6 +523,7 @@ def put_item(request):
 
 
 @item.delete(renderer="sync-json")
+@check_migration
 @default_decorators
 def delete_item(request):
     storage = request.validated["storage"]

--- a/syncstorage/views/decorators.py
+++ b/syncstorage/views/decorators.py
@@ -206,6 +206,10 @@ def with_collection_lock(viewfunc, request):
 def check_migration(viewfunc, request):
     """Check if a given user is in a migration state, return 503.
 
+    This feature is only enabled via the following setting.
+        [storage]
+        allow_migration = True
+
     NOTE: once a user migration has started DO NOT RETURN A 2xx
     WITHOUT REMOVING THE meta/global RECORD!
 

--- a/syncstorage/views/decorators.py
+++ b/syncstorage/views/decorators.py
@@ -28,6 +28,14 @@ ONE_MB = 1024 * 1024
 # How long the client should wait before retrying a conflicting write.
 RETRY_AFTER = 10
 
+# How long a client should wait to retry when a user is in migration.
+# To avoid additional code complexity as well as give ample time for
+# migration, we rely on the client Token timing out, going to the
+# token server and getting the new "spanner" node.
+# *NOTE*: client may not timeout for up to 2 hours. (see
+# DEFAULT_EXPIRED_TOKEN_TIMEOUT)
+MIGRATION_RETRY_AFTER = 300
+
 
 @make_decorator
 def convert_storage_errors(viewfunc, request):
@@ -192,3 +200,19 @@ def with_collection_lock(viewfunc, request):
 
     with lock_collection(user, collection):
         return viewfunc(request)
+
+
+@make_decorator
+def check_migration(viewfunc, request):
+    """Check if a given user is in a migration state, return 503.
+
+    NOTE: once a user migration has started DO NOT RETURN A 2xx
+    WITHOUT REMOVING THE meta/global RECORD!
+
+    """
+    storage = request.validated["storage"]
+    if storage.is_migrating(request.user):
+        raise HTTPServiceUnavailable(
+            headers={"Retry-After": str(MIGRATION_RETRY_AFTER)}
+        )
+    return viewfunc(request)


### PR DESCRIPTION
This branch adds support to look in a `migration` table for a user's
`fxa_uid` record. If it is found, the server will return a 5xx error to
the client preventing sync operations.

NOTE: IT IS IMPORTANT THAT THE SERVER NOT RETURN A 2xx RESULT TO ANY
CLIENT IN MIGRATION STATUS UNLESS THE `meta`/`global` BSO IS RESET.

The `migration` table is created by the `user_migration` script, which
is part of `syncstorage-rs`.