### PR TITLE
Fix Hawk token content validation for new fxa_kid

### DIFF
--- a/syncstorage/tests/functional/test_storage.py
+++ b/syncstorage/tests/functional/test_storage.py
@@ -2248,7 +2248,7 @@ class TestStorageWithBatchUploadDisabled(TestStorage):
         resp = self.retry_post_json(endpoint + commit, [bso5, bso6, bso0],
                                     status=400)
         # This requests a new batch, which is silently ignored and succeeds.
-        commit = '?batch=true&commit=true'.format(batch)
+        commit = '?batch=true&commit=true'
         resp = self.retry_post_json(endpoint + commit, [bso5, bso6, bso0])
         assert 'batch' not in resp.json
         committed = resp.json['modified']

--- a/syncstorage/tests/test_wsgiapp.py
+++ b/syncstorage/tests/test_wsgiapp.py
@@ -185,7 +185,7 @@ class TestWSGIApp(StorageTestCase):
         auth_policy = self.config.registry.getUtility(IAuthenticationPolicy)
         req = self._make_signed_req(42, {
             "fxa_uid": "raw-uid",
-            "fxa_kid": "raw-kid",
+            "fxa_kid": "raw-new_kI-d",
             "hashed_fxa_uid": "hashed-uid",
             "hashed_device_id": "hashed-device-id",
         })
@@ -196,7 +196,7 @@ class TestWSGIApp(StorageTestCase):
         self.assertEquals(req.metrics["metrics_device_id"], "hashed-device-id")
 
         self.assertEquals(req.user["fxa_uid"], "raw-uid")
-        self.assertEquals(req.user["fxa_kid"], "raw-kid")
+        self.assertEquals(req.user["fxa_kid"], "raw-new_kI-d")
 
     def test_validation_of_user_data_from_token(self):
         auth_policy = self.config.registry.getUtility(IAuthenticationPolicy)

--- a/syncstorage/views/authentication.py
+++ b/syncstorage/views/authentication.py
@@ -20,7 +20,7 @@ DEFAULT_EXPIRED_TOKEN_TIMEOUT = 60 * 60 * 2  # 2 hours, in seconds
 # Coarse validation of FxA userid, device ids, and key ids.
 # This is not supposed to catch all invalid cases, but to act as a backstop
 # that the ids are safe to use and store internally.
-VALID_FXA_ID_REGEX = re.compile("^[A-Za-z0-9=-]{1,64}$")
+VALID_FXA_ID_REGEX = re.compile("^[A-Za-z0-9=\\-_]{1,64}$")
 
 
 class SyncStorageAuthenticationPolicy(TokenServerAuthenticationPolicy):


### PR DESCRIPTION
As of mozilla-services/tokenserver#143, the Tokenserver includes the full FxA key-ID into field `fxa_kid` for the Hawk auth token, with an example value being the following:
```
1596115912183-FSK_yn0nhZYlC9CrDYZ6xg
```
...whereas it previously was just the hex-encoded client-state value, which would have been:
```
1522bfca7d278596250bd0ab0d867ac6
```
The actual issue is here, that the storage-server tries to validate the value space for `fxa_kid` after validating the token, but does not account for the value-space of url-safe Base64.