### PR TITLE
Add .dockerignore to reduce docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.*
+local/
+*.egg-info/
+docs/
+**/*.pyc
+syncstorage/tests/

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ pyramid-hawkauth==0.1.0
 pytz==2019.1
 repoze.lru==0.6
 requests==2.20.0
-rsa==4.0
+rsa==4.5
 simplejson==3.8.0
 six==1.10.0
 SQLAlchemy==1.3.3


### PR DESCRIPTION
While testing locally, I noticed that the docker image is getting relatively big, due to the fact that everything from the local workspace gets copied into the image:
```
Sending build context to Docker daemon  119.2MB
Step 1/10 : FROM python:2.7-alpine
...
```

So I created a simple `.dockerignore` file to exclude everything that's not needed inside, resulting in:
```
Sending build context to Docker daemon  349.2kB
Step 1/10 : FROM python:2.7-alpine
...
```

Although this does not apply much to the official images built by CI, it may still provide a more official-like experience when developing and testing locally:
```
server-syncstorage              latest              9217ced25ec4        35 minutes ago      211MB
server-syncstorage              1.8.0-local         d1871e1290f5        10 hours ago        323MB
mozilla/server-syncstorage      1.8.0               7deff4b4f2b2        5 months ago        216MB
```