### PR TITLE
Include tests into docker image to make CircleCI build happy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,3 @@ local/
 *.egg-info/
 docs/
 **/*.pyc
-syncstorage/tests/


### PR DESCRIPTION
With merging #151 , the CircleCI build became broken due to missing tests inside the docker image.