### PR TITLE
Use `requirements.txt` as source of truth for requirements in setup.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-SYSTEMPYTHON = `which python2 python | head -n 1`
+SYSTEMPYTHON = `which python2 pypy python | head -n 1`
 VIRTUALENV = virtualenv --python=$(SYSTEMPYTHON)
 NOSE = local/bin/nosetests -s
 TESTS = syncstorage/tests
 PYTHON = local/bin/python
+EASY_INSTALL = local/bin/easy_install
 PIP = local/bin/pip
 PIP_CACHE = /tmp/pip-cache.${USER}
 BUILD_TMP = /tmp/syncstorage-build.${USER}
@@ -22,13 +23,15 @@ INSTALL = ARCHFLAGS=$(ARCHFLAGS) CFLAGS=$(CFLAGS) $(PIP) install -U -i $(PYPI)
 all:	build
 
 build:
-	$(VIRTUALENV) --no-site-packages ./local
-	$(INSTALL) --upgrade "setuptools>=0.7" pip
+	# The latest `pip` doesn't work with pypy 2.7 on some platforms.
+	# Pin to a working version; ref https://github.com/pypa/pip/issues/8653
+	$(VIRTUALENV) --no-pip ./local
+	$(EASY_INSTALL) pip==20.1.1
+	$(INSTALL) --upgrade "setuptools>=0.7"
 	$(INSTALL) -r requirements.txt
 	$(PYTHON) ./setup.py develop
 
 test:
-	$(INSTALL) nose flake8
 	# Check that flake8 passes before bothering to run anything.
 	# This can really cut down time wasted by typos etc.
 	./local/bin/flake8 syncstorage

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,20 @@
 
 from setuptools import setup, find_packages
 
-install_requires = ['SQLALchemy', 'unittest2', 'simplejson', 'pyramid',
-                    'mozsvc[memcache]>=0.8', 'cornice', 'pyramid_hawkauth',
-                    'PyMySQL', 'pymysql_sa', 'wsgiproxy', 'webtest',
-                    'requests', 'PyBrowserID', 'testfixtures']
+def load_req(filename):
+    """Load a pip style requirement file."""
+    reqs = []
+    with open(filename, "r") as file:
+        for line in file.readlines():
+            line = line.strip()
+            if line.startswith("-r"):
+                content = load_req(line.split(' ')[1])
+                reqs.extend(content)
+                continue
+            reqs.append(line)
+    return reqs
+
+install_requires = load_req("requirements.txt")
 
 entry_points = """
 [paste.app_factory]
@@ -15,7 +25,6 @@ main = syncstorage:main
 """
 
 version = "1.8.0"
-
 
 setup(name='SyncStorage',
       version=version,


### PR DESCRIPTION
Previously, this repo had two sets of requirements: one in `requirements.txt`
that we'd use when building the project via `make`, and one in `setup.py`
that we'd use if installing it as a depenency via pip.

This has been causing problems for self-hosters, so let's have `setup.py`
just read the list of requirements out of `requirements.txt` and avoid
needing to keep two lists of requirements in sync.

(The logic here is copied directly from the tokenserver `setup.py`,
and I've taken the opportunity to copy over some other `Makefile` tweaks
while I'm here).