### PR TITLE
task: upgrade urllib3 to fix safetycheck and dependent lib requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ pyramid==1.9.1
 pyramid-hawkauth==0.1.0
 pytz==2019.1
 repoze.lru==0.6
-requests==2.20.0
+requests==2.25.0
 rsa==4.5
 simplejson==3.8.0
 six==1.10.0
@@ -53,7 +53,7 @@ traceback2==1.4.0
 translationstring==1.3
 umemcache==1.6.3
 unittest2==1.1.0
-urllib3==1.24.2
+urllib3==1.25.9
 venusian==1.0
 waitress==1.4.3
 WebOb==1.7.4


### PR DESCRIPTION
## Description

Noticed when I went to open a separate PR that we're failing safety checks so builds are failing. Upgraded related deps.

## Testing

Ran `make safeycheck` locally - it passes. Now let's wait for CI...

## Issue(s)

Closes [#157](https://github.com/mozilla-services/server-syncstorage/issues/157).
